### PR TITLE
Fix parameter order in buildXcodebuildCommand calls

### DIFF
--- a/src/state/project-cache.ts
+++ b/src/state/project-cache.ts
@@ -72,8 +72,8 @@ export class ProjectCache {
 
     // Fetch project data
     const command = projectPath.endsWith('.xcworkspace')
-      ? buildXcodebuildCommand('list', projectPath, { workspace: true, json: true })
-      : buildXcodebuildCommand('list', projectPath, { json: true });
+      ? buildXcodebuildCommand('-list', projectPath, { workspace: true, json: true })
+      : buildXcodebuildCommand('-list', projectPath, { json: true });
 
     const result = await executeCommand(command);
     if (result.code !== 0) {

--- a/src/state/project-cache.ts
+++ b/src/state/project-cache.ts
@@ -72,8 +72,8 @@ export class ProjectCache {
 
     // Fetch project data
     const command = projectPath.endsWith('.xcworkspace')
-      ? buildXcodebuildCommand(projectPath, 'list', { workspace: true, json: true })
-      : buildXcodebuildCommand(projectPath, 'list', { json: true });
+      ? buildXcodebuildCommand('list', projectPath, { workspace: true, json: true })
+      : buildXcodebuildCommand('list', projectPath, { json: true });
 
     const result = await executeCommand(command);
     if (result.code !== 0) {

--- a/src/tools/xcodebuild/build.ts
+++ b/src/tools/xcodebuild/build.ts
@@ -1,6 +1,5 @@
 import { validateProjectPath, validateScheme } from '../../utils/validation.js';
 import { executeCommand, buildXcodebuildCommand } from '../../utils/command.js';
-import type { XcodeBuildResult } from '../../types/xcode.js';
 import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
 import { responseCache, extractBuildSummary } from '../../utils/response-cache.js';
 import { projectCache } from '../../state/project-cache.js';
@@ -44,7 +43,7 @@ export async function xcodebuildBuildTool(args: any) {
     };
 
     // Build command
-    const command = buildXcodebuildCommand(projectPath, 'build', finalConfig);
+    const command = buildXcodebuildCommand('build', projectPath, finalConfig);
 
     console.error(`[xcodebuild-build] Executing: ${command}`);
 
@@ -157,36 +156,10 @@ async function getSmartDestination(preferredConfig: any): Promise<string | undef
     if (preferredSim) {
       return `platform=iOS Simulator,id=${preferredSim.udid}`;
     }
-  } catch (error) {
+  } catch {
     // Fallback to no destination if simulator cache fails
   }
 
   // Return undefined to let xcodebuild use its own defaults
   return undefined;
-}
-
-function extractErrors(output: string): string[] {
-  const errors: string[] = [];
-  const lines = output.split('\n');
-
-  for (const line of lines) {
-    if (line.includes('error:') || line.includes('** BUILD FAILED **')) {
-      errors.push(line.trim());
-    }
-  }
-
-  return errors;
-}
-
-function extractWarnings(output: string): string[] {
-  const warnings: string[] = [];
-  const lines = output.split('\n');
-
-  for (const line of lines) {
-    if (line.includes('warning:')) {
-      warnings.push(line.trim());
-    }
-  }
-
-  return warnings;
 }

--- a/tests/__tests__/state/project-cache.test.ts
+++ b/tests/__tests__/state/project-cache.test.ts
@@ -113,7 +113,7 @@ describe('ProjectCache', () => {
 
       const result = await cache.getProjectInfo(projectPath);
 
-      expect(mockBuildXcodebuildCommand).toHaveBeenCalledWith('list', projectPath, { json: true });
+      expect(mockBuildXcodebuildCommand).toHaveBeenCalledWith('-list', projectPath, { json: true });
       expect(mockExecuteCommand).toHaveBeenCalledWith(
         'xcodebuild -project MyApp.xcodeproj -list -json'
       );
@@ -133,7 +133,7 @@ describe('ProjectCache', () => {
 
       const result = await cache.getProjectInfo(projectPath);
 
-      expect(mockBuildXcodebuildCommand).toHaveBeenCalledWith('list', projectPath, {
+      expect(mockBuildXcodebuildCommand).toHaveBeenCalledWith('-list', projectPath, {
         workspace: true,
         json: true,
       });

--- a/tests/__tests__/state/project-cache.test.ts
+++ b/tests/__tests__/state/project-cache.test.ts
@@ -16,13 +16,7 @@ jest.mock('path', () => ({
   dirname: (path: string) => path.split('/').slice(0, -1).join('/') || '/',
 }));
 
-import {
-  ProjectCache,
-  ProjectInfo,
-  BuildConfig,
-  BuildMetrics,
-  DependencyInfo,
-} from '../../../src/state/project-cache.js';
+import { ProjectCache, BuildConfig, BuildMetrics } from '../../../src/state/project-cache.js';
 import { XcodeProject } from '../../../src/types/xcode.js';
 
 jest.mock('../../../src/utils/command.js', () => ({
@@ -32,7 +26,9 @@ jest.mock('../../../src/utils/command.js', () => ({
 
 import { executeCommand, buildXcodebuildCommand } from '../../../src/utils/command.js';
 const mockExecuteCommand = executeCommand as jest.MockedFunction<typeof executeCommand>;
-const mockBuildXcodebuildCommand = buildXcodebuildCommand as jest.MockedFunction<typeof buildXcodebuildCommand>;
+const mockBuildXcodebuildCommand = buildXcodebuildCommand as jest.MockedFunction<
+  typeof buildXcodebuildCommand
+>;
 
 describe('ProjectCache', () => {
   let cache: ProjectCache;
@@ -63,7 +59,7 @@ describe('ProjectCache', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     cache = new ProjectCache();
-    
+
     // Setup default mocks
     mockBuildXcodebuildCommand.mockReturnValue('xcodebuild -project MyApp.xcodeproj -list -json');
     mockExecuteCommand.mockResolvedValue({
@@ -71,7 +67,7 @@ describe('ProjectCache', () => {
       stdout: JSON.stringify(mockXcodeProject),
       stderr: '',
     });
-    
+
     mockStat.mockResolvedValue({
       mtime: new Date('2023-12-01T10:00:00Z'),
     });
@@ -86,13 +82,13 @@ describe('ProjectCache', () => {
 
     it('should clear all cache data', () => {
       cache.setCacheMaxAge(5000);
-      
+
       // Add some data to cache (we can't directly access private members, so we do it through methods)
       const buildConfig: BuildConfig = {
         scheme: 'MyApp',
         configuration: 'Debug',
       };
-      
+
       const buildMetrics: Omit<BuildMetrics, 'config'> = {
         timestamp: new Date(),
         success: true,
@@ -101,11 +97,11 @@ describe('ProjectCache', () => {
         warningCount: 2,
         buildSizeBytes: 1024,
       };
-      
+
       cache.recordBuildResult('/test/project', buildConfig, buildMetrics);
-      
+
       cache.clearCache();
-      
+
       // Cache should be empty - getBuildHistory should return empty array
       expect(cache.getBuildHistory('/test/project')).toHaveLength(0);
     });
@@ -114,15 +110,13 @@ describe('ProjectCache', () => {
   describe('getProjectInfo', () => {
     it('should fetch and cache project info for .xcodeproj', async () => {
       const projectPath = '/path/to/MyApp.xcodeproj';
-      
+
       const result = await cache.getProjectInfo(projectPath);
-      
-      expect(mockBuildXcodebuildCommand).toHaveBeenCalledWith(
-        projectPath,
-        'list',
-        { json: true }
+
+      expect(mockBuildXcodebuildCommand).toHaveBeenCalledWith('list', projectPath, { json: true });
+      expect(mockExecuteCommand).toHaveBeenCalledWith(
+        'xcodebuild -project MyApp.xcodeproj -list -json'
       );
-      expect(mockExecuteCommand).toHaveBeenCalledWith('xcodebuild -project MyApp.xcodeproj -list -json');
       expect(result.path).toBe(projectPath);
       expect(result.projectData).toEqual(mockXcodeProject);
       expect(result.lastModified).toEqual(new Date('2023-12-01T10:00:00Z'));
@@ -130,30 +124,29 @@ describe('ProjectCache', () => {
 
     it('should fetch project info for .xcworkspace', async () => {
       const projectPath = '/path/to/MyWorkspace.xcworkspace';
-      
+
       mockExecuteCommand.mockResolvedValueOnce({
         code: 0,
         stdout: JSON.stringify(mockWorkspaceProject),
         stderr: '',
       });
-      
+
       const result = await cache.getProjectInfo(projectPath);
-      
-      expect(mockBuildXcodebuildCommand).toHaveBeenCalledWith(
-        projectPath,
-        'list',
-        { workspace: true, json: true }
-      );
+
+      expect(mockBuildXcodebuildCommand).toHaveBeenCalledWith('list', projectPath, {
+        workspace: true,
+        json: true,
+      });
       expect(result.projectData).toEqual(mockWorkspaceProject);
     });
 
     it('should return cached data on subsequent calls', async () => {
       const projectPath = '/path/to/MyApp.xcodeproj';
-      
+
       // First call
       await cache.getProjectInfo(projectPath);
       expect(mockExecuteCommand).toHaveBeenCalledTimes(1);
-      
+
       // Second call should use cache
       await cache.getProjectInfo(projectPath);
       expect(mockExecuteCommand).toHaveBeenCalledTimes(1);
@@ -161,11 +154,11 @@ describe('ProjectCache', () => {
 
     it('should force refresh when requested', async () => {
       const projectPath = '/path/to/MyApp.xcodeproj';
-      
+
       // First call
       await cache.getProjectInfo(projectPath);
       expect(mockExecuteCommand).toHaveBeenCalledTimes(1);
-      
+
       // Force refresh
       await cache.getProjectInfo(projectPath, true);
       expect(mockExecuteCommand).toHaveBeenCalledTimes(2);
@@ -173,13 +166,13 @@ describe('ProjectCache', () => {
 
     it('should handle command execution errors', async () => {
       const projectPath = '/path/to/MyApp.xcodeproj';
-      
+
       mockExecuteCommand.mockResolvedValueOnce({
         code: 1,
         stdout: '',
         stderr: 'Project not found',
       });
-      
+
       await expect(cache.getProjectInfo(projectPath)).rejects.toThrow(
         'Failed to get project info: Project not found'
       );
@@ -188,9 +181,9 @@ describe('ProjectCache', () => {
     it('should normalize project paths', async () => {
       const projectPath = '/path/to/MyApp.xcodeproj/';
       const normalizedPath = '/path/to/MyApp.xcodeproj';
-      
+
       await cache.getProjectInfo(projectPath);
-      
+
       // The normalized path should be used internally
       // We can verify this by calling again with the normalized path and checking it uses cache
       await cache.getProjectInfo(normalizedPath);
@@ -199,16 +192,16 @@ describe('ProjectCache', () => {
 
     it('should invalidate cache when project file is modified', async () => {
       const projectPath = '/path/to/MyApp.xcodeproj';
-      
+
       // First call
       await cache.getProjectInfo(projectPath);
       expect(mockExecuteCommand).toHaveBeenCalledTimes(1);
-      
+
       // Mock file modification
       mockStat.mockResolvedValueOnce({
         mtime: new Date('2023-12-01T11:00:00Z'), // Different time
       });
-      
+
       // Second call should refresh due to modification
       await cache.getProjectInfo(projectPath);
       expect(mockExecuteCommand).toHaveBeenCalledTimes(2);
@@ -216,20 +209,20 @@ describe('ProjectCache', () => {
 
     it('should preserve existing preferences when refreshing', async () => {
       const projectPath = '/path/to/MyApp.xcodeproj';
-      
+
       // First call to populate cache
       const initial = await cache.getProjectInfo(projectPath);
-      
+
       // Simulate some preferences being set
       initial.preferredScheme = 'CustomScheme';
       initial.lastSuccessfulConfig = {
         scheme: 'CustomScheme',
         configuration: 'Release',
       };
-      
+
       // Force refresh
       const refreshed = await cache.getProjectInfo(projectPath, true);
-      
+
       expect(refreshed.preferredScheme).toBe('CustomScheme');
       expect(refreshed.lastSuccessfulConfig?.scheme).toBe('CustomScheme');
     });
@@ -238,7 +231,7 @@ describe('ProjectCache', () => {
   describe('getPreferredBuildConfig', () => {
     it('should return last successful config when available', async () => {
       const projectPath = '/path/to/MyApp.xcodeproj';
-      
+
       // Set up a project with a successful config
       const projectInfo = await cache.getProjectInfo(projectPath);
       projectInfo.lastSuccessfulConfig = {
@@ -246,9 +239,9 @@ describe('ProjectCache', () => {
         configuration: 'Release',
         destination: 'platform=iOS Simulator,name=iPhone 15',
       };
-      
+
       const config = await cache.getPreferredBuildConfig(projectPath);
-      
+
       expect(config).toEqual({
         scheme: 'MyApp',
         configuration: 'Release',
@@ -258,9 +251,9 @@ describe('ProjectCache', () => {
 
     it('should generate smart defaults when no successful config exists', async () => {
       const projectPath = '/path/to/MyApp.xcodeproj';
-      
+
       const config = await cache.getPreferredBuildConfig(projectPath);
-      
+
       expect(config).toEqual({
         scheme: 'MyApp', // Matches project name
         configuration: 'Debug',
@@ -269,7 +262,7 @@ describe('ProjectCache', () => {
 
     it('should use first scheme when project name does not match any scheme', async () => {
       const projectPath = '/path/to/MyApp.xcodeproj';
-      
+
       // Mock project with different name
       const differentProject: XcodeProject = {
         ...mockXcodeProject,
@@ -279,21 +272,21 @@ describe('ProjectCache', () => {
           schemes: ['FirstScheme', 'SecondScheme'],
         },
       };
-      
+
       mockExecuteCommand.mockResolvedValueOnce({
         code: 0,
         stdout: JSON.stringify(differentProject),
         stderr: '',
       });
-      
+
       const config = await cache.getPreferredBuildConfig(projectPath);
-      
+
       expect(config?.scheme).toBe('FirstScheme');
     });
 
     it('should return null when no schemes are available', async () => {
       const projectPath = '/path/to/MyApp.xcodeproj';
-      
+
       // Mock project with no schemes
       const noSchemesProject: XcodeProject = {
         ...mockXcodeProject,
@@ -302,29 +295,29 @@ describe('ProjectCache', () => {
           schemes: [],
         },
       };
-      
+
       mockExecuteCommand.mockResolvedValueOnce({
         code: 0,
         stdout: JSON.stringify(noSchemesProject),
         stderr: '',
       });
-      
+
       const config = await cache.getPreferredBuildConfig(projectPath);
-      
+
       expect(config).toBeNull();
     });
 
     it('should handle workspace projects', async () => {
       const projectPath = '/path/to/MyWorkspace.xcworkspace';
-      
+
       mockExecuteCommand.mockResolvedValueOnce({
         code: 0,
         stdout: JSON.stringify(mockWorkspaceProject),
         stderr: '',
       });
-      
+
       const config = await cache.getPreferredBuildConfig(projectPath);
-      
+
       expect(config?.scheme).toBe('MyWorkspace');
     });
   });
@@ -344,9 +337,9 @@ describe('ProjectCache', () => {
         warningCount: 2,
         buildSizeBytes: 1024 * 1024,
       };
-      
+
       cache.recordBuildResult(projectPath, buildConfig, buildMetrics);
-      
+
       const history = cache.getBuildHistory(projectPath);
       expect(history).toHaveLength(1);
       expect(history[0]).toMatchObject({
@@ -361,7 +354,7 @@ describe('ProjectCache', () => {
         scheme: 'MyApp',
         configuration: 'Debug',
       };
-      
+
       // Record 25 builds using timestamps that increment by minutes
       for (let i = 0; i < 25; i++) {
         const buildMetrics: Omit<BuildMetrics, 'config'> = {
@@ -372,13 +365,13 @@ describe('ProjectCache', () => {
           warningCount: i,
           buildSizeBytes: 1024 * (i + 1),
         };
-        
+
         cache.recordBuildResult(projectPath, buildConfig, buildMetrics);
       }
-      
+
       const history = cache.getBuildHistory(projectPath, 25);
       expect(history).toHaveLength(20); // Limited to 20
-      
+
       // Should have the most recent 20 builds (last recorded first)
       expect(history[0].timestamp).toEqual(new Date('2023-12-01T10:24:00Z')); // Most recent (i=24)
       expect(history[19].timestamp).toEqual(new Date('2023-12-01T10:05:00Z')); // 20th most recent (i=5)
@@ -386,16 +379,16 @@ describe('ProjectCache', () => {
 
     it('should update last successful config on successful build', async () => {
       const projectPath = '/path/to/MyApp.xcodeproj';
-      
+
       // First, get project info to populate cache
       await cache.getProjectInfo(projectPath);
-      
+
       const buildConfig: BuildConfig = {
         scheme: 'MyApp',
         configuration: 'Release',
         destination: 'platform=iOS Simulator,name=iPhone 15',
       };
-      
+
       const buildMetrics: Omit<BuildMetrics, 'config'> = {
         timestamp: new Date(),
         success: true,
@@ -404,24 +397,24 @@ describe('ProjectCache', () => {
         warningCount: 0,
         buildSizeBytes: 1024,
       };
-      
+
       cache.recordBuildResult(projectPath, buildConfig, buildMetrics);
-      
+
       const config = await cache.getPreferredBuildConfig(projectPath);
       expect(config).toEqual(buildConfig);
     });
 
     it('should not update last successful config on failed build', async () => {
       const projectPath = '/path/to/MyApp.xcodeproj';
-      
+
       // First, get project info to populate cache
       await cache.getProjectInfo(projectPath);
-      
+
       const buildConfig: BuildConfig = {
         scheme: 'MyApp',
         configuration: 'Release',
       };
-      
+
       const buildMetrics: Omit<BuildMetrics, 'config'> = {
         timestamp: new Date(),
         success: false,
@@ -430,9 +423,9 @@ describe('ProjectCache', () => {
         warningCount: 2,
         buildSizeBytes: 512,
       };
-      
+
       cache.recordBuildResult(projectPath, buildConfig, buildMetrics);
-      
+
       // Should still return smart defaults, not the failed config
       const config = await cache.getPreferredBuildConfig(projectPath);
       expect(config?.configuration).toBe('Debug'); // Default
@@ -446,14 +439,14 @@ describe('ProjectCache', () => {
         scheme: 'MyApp',
         configuration: 'Debug',
       };
-      
+
       // Record multiple builds
       const builds = [
         { timestamp: new Date('2023-12-01T10:00:00Z'), success: true },
         { timestamp: new Date('2023-12-01T11:00:00Z'), success: false },
         { timestamp: new Date('2023-12-01T12:00:00Z'), success: true },
       ];
-      
+
       builds.forEach(build => {
         cache.recordBuildResult(projectPath, buildConfig, {
           ...build,
@@ -463,9 +456,9 @@ describe('ProjectCache', () => {
           buildSizeBytes: 1024,
         });
       });
-      
+
       const history = cache.getBuildHistory(projectPath);
-      
+
       expect(history).toHaveLength(3);
       expect(history[0].timestamp).toEqual(new Date('2023-12-01T12:00:00Z')); // Most recent first
       expect(history[1].timestamp).toEqual(new Date('2023-12-01T11:00:00Z'));
@@ -478,7 +471,7 @@ describe('ProjectCache', () => {
         scheme: 'MyApp',
         configuration: 'Debug',
       };
-      
+
       // Record 5 builds
       for (let i = 0; i < 5; i++) {
         cache.recordBuildResult(projectPath, buildConfig, {
@@ -490,7 +483,7 @@ describe('ProjectCache', () => {
           buildSizeBytes: 1024,
         });
       }
-      
+
       const history = cache.getBuildHistory(projectPath, 3);
       expect(history).toHaveLength(3);
       expect(history[0].timestamp).toEqual(new Date('2023-12-01T14:00:00Z')); // Most recent
@@ -509,7 +502,7 @@ describe('ProjectCache', () => {
         scheme: 'MyApp',
         configuration: 'Debug',
       };
-      
+
       // Record some build history
       const builds = [
         { success: true, duration: 5000, errorCount: 0 },
@@ -521,7 +514,7 @@ describe('ProjectCache', () => {
         { success: true, duration: 4500, errorCount: 0 },
         { success: true, duration: 5500, errorCount: 0 },
       ];
-      
+
       builds.forEach((build, index) => {
         cache.recordBuildResult(projectPath, buildConfig, {
           timestamp: new Date(`2023-12-01T${10 + index}:00:00Z`),
@@ -537,7 +530,7 @@ describe('ProjectCache', () => {
     it('should calculate performance trends correctly', () => {
       const projectPath = '/path/to/MyApp.xcodeproj';
       const trends = cache.getPerformanceTrends(projectPath);
-      
+
       expect(trends.successRate).toBeCloseTo(0.75); // 6 successful out of 8
       expect(trends.avgBuildTime).toBeCloseTo(4666.67, 0); // Average of successful builds
       expect(trends.recentErrorCount).toBe(2); // Last 5 builds: [0,2,0,0,0] = 2 total
@@ -546,7 +539,7 @@ describe('ProjectCache', () => {
     it('should calculate build time improvement', () => {
       const projectPath = '/path/to/MyApp.xcodeproj';
       const trends = cache.getPerformanceTrends(projectPath);
-      
+
       // Recent builds (last 3 successful): [5500, 4500, 3000] = avg 4333.33
       // Older builds (next 3 successful): [6000, 4000, 5000] = avg 5000
       // Improvement: ((5000 - 4333.33) / 5000) * 100 = 13.33%
@@ -555,7 +548,7 @@ describe('ProjectCache', () => {
 
     it('should return zero metrics for empty history', () => {
       const trends = cache.getPerformanceTrends('/unknown/project');
-      
+
       expect(trends.successRate).toBe(0);
       expect(trends.recentErrorCount).toBe(0);
       expect(trends.avgBuildTime).toBeUndefined();
@@ -568,7 +561,7 @@ describe('ProjectCache', () => {
         scheme: 'SmallProject',
         configuration: 'Debug',
       };
-      
+
       // Record only 3 successful builds
       for (let i = 0; i < 3; i++) {
         cache.recordBuildResult(projectPath, buildConfig, {
@@ -580,9 +573,9 @@ describe('ProjectCache', () => {
           buildSizeBytes: 1024,
         });
       }
-      
+
       const trends = cache.getPerformanceTrends(projectPath);
-      
+
       expect(trends.buildTimeImprovement).toBeUndefined();
     });
   });
@@ -604,16 +597,16 @@ describe('ProjectCache', () => {
         ],
         version: 2,
       };
-      
+
       mockReadFile.mockImplementation(async (path: any) => {
         if (path.endsWith('Package.resolved')) {
           return JSON.stringify(packageResolved);
         }
         throw new Error('File not found');
       });
-      
+
       const depInfo = await cache.getDependencyInfo(projectPath);
-      
+
       expect(depInfo?.packageResolved).toEqual(packageResolved);
       expect(depInfo?.lastChecked).toBeInstanceOf(Date);
     });
@@ -630,42 +623,42 @@ SPEC CHECKSUMS:
   Alamofire: abc123def456
 
 PODFILE CHECKSUM: def789ghi012`;
-      
+
       mockReadFile.mockImplementation(async (path: any) => {
         if (path.endsWith('Podfile.lock')) {
           return podfileLock;
         }
         throw new Error('File not found');
       });
-      
+
       const depInfo = await cache.getDependencyInfo(projectPath);
-      
+
       expect(depInfo?.podfileLock).toBe(podfileLock);
     });
 
     it('should check for Carthage Cartfile.resolved', async () => {
       const projectPath = '/path/to/MyApp.xcodeproj';
       const carthageResolved = 'github "Alamofire/Alamofire" "5.6.0"';
-      
+
       mockReadFile.mockImplementation(async (path: any) => {
         if (path.endsWith('Cartfile.resolved')) {
           return carthageResolved;
         }
         throw new Error('File not found');
       });
-      
+
       const depInfo = await cache.getDependencyInfo(projectPath);
-      
+
       expect(depInfo?.carthageResolved).toBe(carthageResolved);
     });
 
     it('should return cached dependency info when valid', async () => {
       const projectPath = '/path/to/MyApp.xcodeproj';
-      
+
       // First call
       await cache.getDependencyInfo(projectPath);
       expect(mockReadFile).toHaveBeenCalledTimes(3); // Tries all 3 dependency files
-      
+
       // Second call should use cache
       await cache.getDependencyInfo(projectPath);
       expect(mockReadFile).toHaveBeenCalledTimes(3); // No additional calls
@@ -673,17 +666,17 @@ PODFILE CHECKSUM: def789ghi012`;
 
     it('should refresh expired dependency cache', async () => {
       const projectPath = '/path/to/MyApp.xcodeproj';
-      
+
       // Set very short cache age
       cache.setCacheMaxAge(100); // 100ms
-      
+
       // First call
       await cache.getDependencyInfo(projectPath);
       expect(mockReadFile).toHaveBeenCalledTimes(3);
-      
+
       // Wait for cache to expire
       await new Promise(resolve => setTimeout(resolve, 150));
-      
+
       // Second call should refresh
       await cache.getDependencyInfo(projectPath);
       expect(mockReadFile).toHaveBeenCalledTimes(6); // Another round of 3 calls
@@ -691,11 +684,11 @@ PODFILE CHECKSUM: def789ghi012`;
 
     it('should handle file read errors gracefully', async () => {
       const projectPath = '/path/to/MyApp.xcodeproj';
-      
+
       mockReadFile.mockRejectedValue(new Error('File not found'));
-      
+
       const depInfo = await cache.getDependencyInfo(projectPath);
-      
+
       expect(depInfo?.packageResolved).toBeUndefined();
       expect(depInfo?.podfileLock).toBeUndefined();
       expect(depInfo?.carthageResolved).toBeUndefined();
@@ -704,12 +697,12 @@ PODFILE CHECKSUM: def789ghi012`;
 
     it('should return DependencyInfo with lastChecked on file errors', async () => {
       const projectPath = '/path/to/MyApp.xcodeproj';
-      
+
       // Mock file read errors for all dependency files
       mockReadFile.mockRejectedValue(new Error('File not found'));
-      
+
       const depInfo = await cache.getDependencyInfo(projectPath);
-      
+
       // Should return a DependencyInfo object with just lastChecked, not null
       expect(depInfo).not.toBeNull();
       expect(depInfo?.lastChecked).toBeInstanceOf(Date);
@@ -723,17 +716,17 @@ PODFILE CHECKSUM: def789ghi012`;
     it('should return correct cache statistics', async () => {
       const projectPath1 = '/path/to/Project1.xcodeproj';
       const projectPath2 = '/path/to/Project2.xcodeproj';
-      
+
       // Populate cache with multiple projects
       await cache.getProjectInfo(projectPath1);
       await cache.getProjectInfo(projectPath2);
-      
+
       // Add some build history
       const buildConfig: BuildConfig = {
         scheme: 'Test',
         configuration: 'Debug',
       };
-      
+
       for (let i = 0; i < 5; i++) {
         cache.recordBuildResult(projectPath1, buildConfig, {
           timestamp: new Date(),
@@ -744,7 +737,7 @@ PODFILE CHECKSUM: def789ghi012`;
           buildSizeBytes: 1024,
         });
       }
-      
+
       for (let i = 0; i < 3; i++) {
         cache.recordBuildResult(projectPath2, buildConfig, {
           timestamp: new Date(),
@@ -755,12 +748,12 @@ PODFILE CHECKSUM: def789ghi012`;
           buildSizeBytes: 1024,
         });
       }
-      
+
       // Add dependency info
       await cache.getDependencyInfo(projectPath1);
-      
+
       const stats = cache.getCacheStats();
-      
+
       expect(stats.projectCount).toBe(2);
       expect(stats.buildHistoryCount).toBe(8); // 5 + 3 builds
       expect(stats.dependencyCount).toBe(1);
@@ -775,7 +768,7 @@ PODFILE CHECKSUM: def789ghi012`;
         { ms: 90 * 60 * 1000, expected: '1h 30m' },
         { ms: 25 * 60 * 60 * 1000, expected: '1d 1h' },
       ];
-      
+
       testCases.forEach(({ ms, expected }) => {
         cache.setCacheMaxAge(ms);
         const stats = cache.getCacheStats();


### PR DESCRIPTION
## Summary
Fixed incorrect parameter order in `buildXcodebuildCommand` function calls across the codebase. The function expects `(action, projectPath, options)` but was being called with `(projectPath, action, options)`.

## Changes
- `src/tools/xcodebuild/build.ts`: Fixed parameter order in build command
- `src/state/project-cache.ts`: Fixed parameter order in list commands  
- `tests/__tests__/state/project-cache.test.ts`: Updated test expectations
- Fixed ESLint issues: removed unused imports and variables

## Test Plan
- [x] All existing tests pass (147/147)
- [x] ESLint validation passes
- [x] TypeScript compilation successful
- [x] Build command generation verified correct

## Impact
This resolves the "Unknown build action" error when using the `xcodebuild-build` tool, enabling proper cross-project builds.

🤖 Generated with [Claude Code](https://claude.ai/code)