### PR TITLE
docs: redesign README with objective, technical focus

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # XC-MCP: Intelligent Xcode MCP Server
 
 [![codecov](https://codecov.io/gh/conorluddy/xc-mcp/graph/badge.svg?token=4CKBMDTENZ)](https://codecov.io/gh/conorluddy/xc-mcp) 
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/conorluddy/xc-mcp)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 **Problem**: MCP clients can't use Xcode CLI tools because `simctl list` returns 57,000+ tokens, exceeding MCP limits.  


### PR DESCRIPTION
## Summary
- Redesign README from 567 to 233 lines (58% reduction) with objective, technical focus
- Lead with clear problem statement: MCP token overflow preventing Xcode CLI tool usage
- Highlight progressive disclosure solution achieving 96% token reduction (57k → 2k tokens)

## Key Changes
- **Remove hype language**: Eliminated excessive emojis, "revolutionary", "breakthrough" terminology
- **Clear value proposition**: Problem → Solution → Result format in opening lines
- **Logical structure**: Flow from problem understanding to usage to reference
- **Practical examples**: Show actual progressive disclosure workflow with code
- **Comprehensive tool table**: Easy-to-scan reference for all 12 tools
- **Developer-focused**: Technical benefits over marketing language

## Content Improvements
- **Quick Start**: Simple installation and MCP configuration
- **Why This Exists**: Clear explanation of MCP token limits and progressive disclosure solution
- **Usage Examples**: Practical workflows showing token reduction in action
- **Tool Reference**: Organized table with progressive disclosure indicators
- **Streamlined sections**: Installation, configuration, development commands

The redesigned README targets developers using MCP clients, clearly communicating why this tool exists (solving token overflow), what problems it solves (96% token reduction), and how to use it effectively.

🤖 Generated with [Claude Code](https://claude.ai/code)