### PR TITLE
chore: bump version to 1.0.4 and add npm badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # XC-MCP: Intelligent Xcode MCP Server
 
+[![npm version](https://img.shields.io/npm/v/xc-mcp.svg)](https://www.npmjs.com/package/xc-mcp)
+[![npm downloads](https://img.shields.io/npm/dm/xc-mcp.svg)](https://www.npmjs.com/package/xc-mcp)
+[![Node.js version](https://img.shields.io/node/v/xc-mcp.svg)](https://nodejs.org)
 [![codecov](https://codecov.io/gh/conorluddy/xc-mcp/graph/badge.svg?token=4CKBMDTENZ)](https://codecov.io/gh/conorluddy/xc-mcp) 
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/conorluddy/xc-mcp)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xc-mcp",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "MCP server that wraps Xcode command-line tools for iOS/macOS development workflows",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
## Summary
- Bump version from 1.0.3 to 1.0.4 in package.json
- Add npm version badge to show current package version
- Add npm downloads badge to show package popularity  
- Add Node.js version badge to show compatibility requirements

## Test plan
- [x] All tests pass (281/281)
- [x] Pre-commit hooks successful
- [x] Version correctly updated in package.json
- [x] Badges display properly in README

🤖 Generated with [Claude Code](https://claude.ai/code)