### PR TITLE
feat: add debug-workflow prompt to prevent testing stale app versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xc-mcp",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "MCP server that wraps Xcode command-line tools for iOS/macOS development workflows",
   "main": "dist/index.js",
   "type": "module",

--- a/src/tools/prompts/debug-workflow.ts
+++ b/src/tools/prompts/debug-workflow.ts
@@ -1,0 +1,105 @@
+import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
+
+interface DebugWorkflowArgs {
+  projectPath: string;
+  scheme: string;
+  simulator?: string;
+}
+
+export async function debugWorkflowPrompt(args: any) {
+  const { projectPath, scheme, simulator } = args as DebugWorkflowArgs;
+
+  if (!projectPath || !scheme) {
+    throw new McpError(
+      ErrorCode.InvalidRequest,
+      'debug-workflow requires projectPath and scheme arguments'
+    );
+  }
+
+  const simulatorText = simulator
+    ? ` targeting simulator "${simulator}"`
+    : ' (will auto-select optimal simulator)';
+
+  return {
+    description: 'iOS Debug Workflow - Complete build, install, and test cycle',
+    messages: [
+      {
+        role: 'user' as const,
+        content: {
+          type: 'text' as const,
+          text: `iOS Debug Workflow for project: ${projectPath}
+
+🚨 **CRITICAL: After ANY code changes, you MUST REBUILD to get a FRESH INSTALL!**
+🚨 **Without rebuilding, you're testing the OLD cached version = wasted time!**
+
+**Project**: ${projectPath}
+**Scheme**: ${scheme}${simulatorText}
+
+## Essential Steps (NEVER skip these):
+
+### 1. 🏗️ BUILD (ALWAYS FIRST)
+Call \`xcodebuild-build\` with:
+- projectPath: "${projectPath}"
+- scheme: "${scheme}"${simulator ? `\n- destination: "platform=iOS Simulator,name=${simulator}"` : ''}
+
+⚠️ **VALIDATION CHECKPOINT**: Build MUST succeed before proceeding!
+
+### 2. 🔍 VALIDATE BUILD SUCCESS
+- Check xcodebuild-build response for \`"success": true\`
+- If build fails, fix errors and restart from step 1
+- DO NOT proceed to testing with a failed build
+
+### 3. 📱 FRESH REINSTALL (Automatic but Critical)
+- App automatically REINSTALLS FRESH to simulator during successful build
+- This OVERWRITES the old version with your new changes
+- The fresh install happens automatically - no separate step needed
+- **CRITICAL**: Without rebuilding, you'll test the OLD cached version!
+
+### 4. 🧪 TEST YOUR CHANGES
+- Launch your app on the simulator
+- Test the specific changes you made
+- Verify expected behavior
+
+## 🔄 **AFTER MAKING CODE CHANGES**
+**You MUST restart from Step 1 (BUILD) - never test without rebuilding!**
+
+## ⚠️ Common Mistakes to Avoid:
+❌ **FATAL ERROR**: Testing without rebuilding after code changes
+❌ **FATAL ERROR**: Testing the old cached app version instead of fresh rebuild
+❌ Proceeding to test after a failed build
+❌ Forgetting to validate build success
+❌ Assuming your code changes are active without rebuilding
+
+## 🎯 Remember:
+**REBUILD = FRESH REINSTALL = NEW CODE ACTIVE**
+**NO REBUILD = OLD CACHED APP = WASTED TIME DEBUGGING**
+
+This workflow ensures you're always testing the LATEST version of your code changes.`,
+        },
+      },
+    ],
+  };
+}
+
+export const debugWorkflowPromptDefinition = {
+  name: 'debug-workflow',
+  description:
+    'Complete iOS debug workflow: build → install → test cycle with validation to prevent testing stale app versions',
+  arguments: [
+    {
+      name: 'projectPath',
+      description: 'Path to .xcodeproj or .xcworkspace file',
+      required: true,
+    },
+    {
+      name: 'scheme',
+      description: 'Build scheme name',
+      required: true,
+    },
+    {
+      name: 'simulator',
+      description: 'Target simulator (optional - will use smart defaults if not provided)',
+      required: false,
+    },
+  ],
+};

--- a/src/tools/prompts/debug-workflow.ts
+++ b/src/tools/prompts/debug-workflow.ts
@@ -27,54 +27,64 @@ export async function debugWorkflowPrompt(args: any) {
         role: 'user' as const,
         content: {
           type: 'text' as const,
-          text: `iOS Debug Workflow for project: ${projectPath}
+          text: `XC-MCP iOS Debug Workflow for project: ${projectPath}
 
 🚨 **CRITICAL: After ANY code changes, you MUST REBUILD to get a FRESH INSTALL!**
 🚨 **Without rebuilding, you're testing the OLD cached version = wasted time!**
+🚨 **Always use XC-MCP tools - they provide intelligent caching and better error handling than raw CLI!**
 
 **Project**: ${projectPath}
 **Scheme**: ${scheme}${simulatorText}
 
 ## Essential Steps (NEVER skip these):
 
-### 1. 🏗️ BUILD (ALWAYS FIRST)
-Call \`xcodebuild-build\` with:
+### 1. 🏗️ BUILD (ALWAYS FIRST) - Use XC-MCP Tool
+**Call the \`xcodebuild-build\` XC-MCP tool** (NOT raw xcodebuild CLI):
 - projectPath: "${projectPath}"
 - scheme: "${scheme}"${simulator ? `\n- destination: "platform=iOS Simulator,name=${simulator}"` : ''}
 
+🧠 **XC-MCP Advantage**: Intelligent caching, progressive disclosure, and build optimization!
+
 ⚠️ **VALIDATION CHECKPOINT**: Build MUST succeed before proceeding!
 
-### 2. 🔍 VALIDATE BUILD SUCCESS
-- Check xcodebuild-build response for \`"success": true\`
-- If build fails, fix errors and restart from step 1
+### 2. 🔍 VALIDATE BUILD SUCCESS  
+- Check the \`xcodebuild-build\` tool response for \`"success": true\`
+- If build fails, use \`xcodebuild-get-details\` tool for full error logs
+- Fix errors and restart from step 1
 - DO NOT proceed to testing with a failed build
 
-### 3. 📱 FRESH REINSTALL (Automatic but Critical)
-- App automatically REINSTALLS FRESH to simulator during successful build
-- This OVERWRITES the old version with your new changes
-- The fresh install happens automatically - no separate step needed
-- **CRITICAL**: Without rebuilding, you'll test the OLD cached version!
+### 3. 🔄 ENSURE SIMULATOR IS READY (If Needed)
+- If simulator isn't running, use \`simctl-boot\` XC-MCP tool to start it
+- Use \`simctl-list\` tool to see available simulators (not raw simctl!)
 
-### 4. 🧪 TEST YOUR CHANGES
+### 4. 📱 FRESH REINSTALL (Automatic but Critical)
+- App automatically REINSTALLS FRESH to simulator during successful XC-MCP build
+- This OVERWRITES the old version with your new changes
+- The fresh install happens automatically during the build process
+- **CRITICAL**: Without using XC-MCP build tools, you'll test the OLD cached version!
+
+### 5. 🧪 TEST YOUR CHANGES
 - Launch your app on the simulator
-- Test the specific changes you made
+- Test the specific changes you made  
 - Verify expected behavior
 
 ## 🔄 **AFTER MAKING CODE CHANGES**
-**You MUST restart from Step 1 (BUILD) - never test without rebuilding!**
+**You MUST restart from Step 1 (XC-MCP BUILD TOOL) - never test without rebuilding!**
 
 ## ⚠️ Common Mistakes to Avoid:
+❌ **FATAL ERROR**: Using raw xcodebuild CLI instead of XC-MCP tools
 ❌ **FATAL ERROR**: Testing without rebuilding after code changes
 ❌ **FATAL ERROR**: Testing the old cached app version instead of fresh rebuild
 ❌ Proceeding to test after a failed build
-❌ Forgetting to validate build success
+❌ Forgetting to validate build success with XC-MCP tools
 ❌ Assuming your code changes are active without rebuilding
 
 ## 🎯 Remember:
-**REBUILD = FRESH REINSTALL = NEW CODE ACTIVE**
-**NO REBUILD = OLD CACHED APP = WASTED TIME DEBUGGING**
+**XC-MCP REBUILD = FRESH REINSTALL = NEW CODE ACTIVE**
+**NO XC-MCP REBUILD = OLD CACHED APP = WASTED TIME DEBUGGING**
+**ALWAYS USE XC-MCP TOOLS FOR INTELLIGENT CACHING & ERROR HANDLING**
 
-This workflow ensures you're always testing the LATEST version of your code changes.`,
+This workflow ensures you're always testing the LATEST version of your code changes using XC-MCP's intelligent tooling.`,
         },
       },
     ],


### PR DESCRIPTION
## Summary
Adds a focused `debug-workflow` MCP prompt that prevents AI agents from forgetting to rebuild iOS apps after code changes, solving the critical issue of wasted debugging time testing old cached versions.

## Problem Solved
AI agents frequently forget the essential iOS debugging sequence:
1. Make code changes
2. **REBUILD** (critical step often skipped\!)
3. Fresh install happens automatically  
4. Test changes

Without rebuilding, agents test old cached app versions, leading to confusion and wasted time.

## Solution
Single surgical `debug-workflow` prompt that provides:
- 🚨 Crystal clear "REBUILD = FRESH REINSTALL = NEW CODE ACTIVE" messaging  
- ⚠️ Multiple "FATAL ERROR" warnings about testing without rebuilding
- 📋 Step-by-step workflow with validation checkpoints
- 🎯 Project-specific guidance (takes projectPath, scheme, optional simulator)

## Implementation
- ✅ Clean modular architecture following XC-MCP patterns
- ✅ New `src/tools/prompts/debug-workflow.ts` following tool organization
- ✅ Minimal changes to main `index.ts` (just imports and handlers)
- ✅ Proper TypeScript interfaces and error handling
- ✅ All 281 tests pass, linting clean
- ✅ Version bumped to 1.0.5

## Usage
Agents can now call the `debug-workflow` prompt with project details:
```json
{
  "name": "debug-workflow", 
  "arguments": {
    "projectPath": "/path/to/MyApp.xcodeproj",
    "scheme": "MyApp",
    "simulator": "iPhone 15" // optional
  }
}
```

This keeps XC-MCP surgical and focused while solving a critical workflow gap that affects AI agent debugging efficiency.

## Test plan
- [x] Build compiles successfully
- [x] All existing tests pass (281/281) 
- [x] ESLint passes with no warnings
- [x] Pre-commit hooks pass
- [x] Prompt follows XC-MCP architectural patterns
- [x] Clean modular code organization

🤖 Generated with [Claude Code](https://claude.ai/code)