### PR TITLE
feat: Add --mini CLI flag for reduced token usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,19 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 }
 ```
 
+**Minimal Mode** (for Claude Code and other clients that don't support `defer_loading`):
+```json
+{
+  "mcpServers": {
+    "xc-mcp": {
+      "command": "npx",
+      "args": ["-y", "xc-mcp", "--mini"]
+    }
+  }
+}
+```
+The `--mini` flag reduces tool descriptions from ~18.7k tokens to ~540 tokens (~97% reduction). Use `rtfm` for full documentation on-demand.
+
 ---
 
 ## Token Optimization Architecture

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,21 @@
+/**
+ * CLI configuration for XC-MCP server
+ * Parses command line arguments and environment variables
+ */
+
+export interface MCPConfig {
+  /** Use minimal tool descriptions (~70 chars) instead of full docs */
+  minimalDescriptions: boolean;
+  /** Enable defer_loading hint for MCP clients that support it */
+  deferLoading: boolean;
+}
+
+function parseArgs(): MCPConfig {
+  const args = process.argv.slice(2);
+  return {
+    minimalDescriptions: args.includes('--mini') || args.includes('-m'),
+    deferLoading: process.env.XC_MCP_DEFER_LOADING !== 'false',
+  };
+}
+
+export const config = parseArgs();

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,9 +5,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { z } from 'zod';
 import { registerAllTools } from './registry/index.js';
 import { debugWorkflowPrompt } from './tools/prompts/debug-workflow.js';
-
-// Environment variable to disable defer_loading (for debugging/testing)
-const ENABLE_DEFER_LOADING = process.env.XC_MCP_DEFER_LOADING !== 'false';
+import { config } from './config.js';
 
 class XcodeCLIMCPServer {
   private server: McpServer;
@@ -100,7 +98,7 @@ Call \`rtfm\` with tool name for full documentation. Example: \`rtfm({ toolName:
     registerAllTools(this.server);
 
     console.error(
-      `XC-MCP v3.0.1: ${ENABLE_DEFER_LOADING ? 'defer_loading enabled' : 'defer_loading disabled'} for all tools.`
+      `XC-MCP v3.0.1: descriptions=${config.minimalDescriptions ? 'mini' : 'full'}, defer_loading=${config.deferLoading ? 'enabled' : 'disabled'}`
     );
   }
 

--- a/src/registry/cache.ts
+++ b/src/registry/cache.ts
@@ -2,10 +2,13 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import { validateXcodeInstallation } from '../utils/validation.js';
-import { cacheTool } from '../tools/cache/index.js';
-import { CACHE_DOCS } from '../tools/cache/index.js';
-import { persistenceTool } from '../tools/persistence/index.js';
-import { PERSISTENCE_DOCS } from '../tools/persistence/index.js';
+import { getDescription } from './types.js';
+import { cacheTool, CACHE_DOCS, CACHE_DOCS_MINI } from '../tools/cache/index.js';
+import {
+  persistenceTool,
+  PERSISTENCE_DOCS,
+  PERSISTENCE_DOCS_MINI,
+} from '../tools/persistence/index.js';
 
 const ENABLE_DEFER_LOADING = process.env.XC_MCP_DEFER_LOADING !== 'false';
 const DEFER_LOADING_CONFIG = ENABLE_DEFER_LOADING
@@ -17,7 +20,7 @@ export function registerCacheTools(server: McpServer): void {
   server.registerTool(
     'cache',
     {
-      description: CACHE_DOCS,
+      description: getDescription(CACHE_DOCS, CACHE_DOCS_MINI),
       inputSchema: {
         operation: z.enum(['get-stats', 'get-config', 'set-config', 'clear']),
         cacheType: z.enum(['simulator', 'project', 'response', 'all']).optional(),
@@ -46,7 +49,7 @@ export function registerCacheTools(server: McpServer): void {
   server.registerTool(
     'persistence',
     {
-      description: PERSISTENCE_DOCS,
+      description: getDescription(PERSISTENCE_DOCS, PERSISTENCE_DOCS_MINI),
       inputSchema: {
         operation: z.enum(['enable', 'disable', 'status']),
         cacheDir: z.string().optional(),

--- a/src/registry/idb.ts
+++ b/src/registry/idb.ts
@@ -1,23 +1,43 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import { idbTargetsRouter } from '../tools/idb/targets/index.js';
-import { IDB_TARGETS_DOCS } from '../tools/idb/targets/index.js';
-import { idbUiTapTool } from '../tools/idb/ui-tap.js';
-import { IDB_UI_TAP_DOCS } from '../tools/idb/ui-tap.js';
-import { idbUiInputTool } from '../tools/idb/ui-input.js';
-import { IDB_UI_INPUT_DOCS } from '../tools/idb/ui-input.js';
-import { idbUiGestureTool } from '../tools/idb/ui-gesture.js';
-import { IDB_UI_GESTURE_DOCS } from '../tools/idb/ui-gesture.js';
-import { idbUiDescribeTool } from '../tools/idb/ui-describe.js';
-import { IDB_UI_DESCRIBE_DOCS } from '../tools/idb/ui-describe.js';
-import { idbUiFindElementTool } from '../tools/idb/ui-find-element.js';
-import { IDB_UI_FIND_ELEMENT_DOCS } from '../tools/idb/ui-find-element.js';
-import { accessibilityQualityCheckTool } from '../tools/idb/accessibility-quality-check.js';
-import { ACCESSIBILITY_QUALITY_CHECK_DOCS } from '../tools/idb/accessibility-quality-check.js';
-import { idbListAppsTool } from '../tools/idb/list-apps.js';
-import { IDB_LIST_APPS_DOCS } from '../tools/idb/list-apps.js';
-import { idbAppTool } from '../tools/idb/app/index.js';
-import { IDB_APP_DOCS } from '../tools/idb/app/index.js';
+import { getDescription } from './types.js';
+import {
+  idbTargetsRouter,
+  IDB_TARGETS_DOCS,
+  IDB_TARGETS_DOCS_MINI,
+} from '../tools/idb/targets/index.js';
+import { idbUiTapTool, IDB_UI_TAP_DOCS, IDB_UI_TAP_DOCS_MINI } from '../tools/idb/ui-tap.js';
+import {
+  idbUiInputTool,
+  IDB_UI_INPUT_DOCS,
+  IDB_UI_INPUT_DOCS_MINI,
+} from '../tools/idb/ui-input.js';
+import {
+  idbUiGestureTool,
+  IDB_UI_GESTURE_DOCS,
+  IDB_UI_GESTURE_DOCS_MINI,
+} from '../tools/idb/ui-gesture.js';
+import {
+  idbUiDescribeTool,
+  IDB_UI_DESCRIBE_DOCS,
+  IDB_UI_DESCRIBE_DOCS_MINI,
+} from '../tools/idb/ui-describe.js';
+import {
+  idbUiFindElementTool,
+  IDB_UI_FIND_ELEMENT_DOCS,
+  IDB_UI_FIND_ELEMENT_DOCS_MINI,
+} from '../tools/idb/ui-find-element.js';
+import {
+  accessibilityQualityCheckTool,
+  ACCESSIBILITY_QUALITY_CHECK_DOCS,
+  ACCESSIBILITY_QUALITY_CHECK_DOCS_MINI,
+} from '../tools/idb/accessibility-quality-check.js';
+import {
+  idbListAppsTool,
+  IDB_LIST_APPS_DOCS,
+  IDB_LIST_APPS_DOCS_MINI,
+} from '../tools/idb/list-apps.js';
+import { idbAppTool, IDB_APP_DOCS, IDB_APP_DOCS_MINI } from '../tools/idb/app/index.js';
 
 const ENABLE_DEFER_LOADING = process.env.XC_MCP_DEFER_LOADING !== 'false';
 const DEFER_LOADING_CONFIG = ENABLE_DEFER_LOADING
@@ -29,7 +49,7 @@ export function registerIdbTools(server: McpServer): void {
   server.registerTool(
     'idb-targets',
     {
-      description: IDB_TARGETS_DOCS,
+      description: getDescription(IDB_TARGETS_DOCS, IDB_TARGETS_DOCS_MINI),
       inputSchema: {
         operation: z.enum(['list', 'describe', 'focus', 'connect', 'disconnect']),
         udid: z.string().optional(),
@@ -45,7 +65,7 @@ export function registerIdbTools(server: McpServer): void {
   server.registerTool(
     'idb-ui-tap',
     {
-      description: IDB_UI_TAP_DOCS,
+      description: getDescription(IDB_UI_TAP_DOCS, IDB_UI_TAP_DOCS_MINI),
       inputSchema: {
         udid: z.string().optional(),
         x: z.number(),
@@ -70,7 +90,7 @@ export function registerIdbTools(server: McpServer): void {
   server.registerTool(
     'idb-ui-input',
     {
-      description: IDB_UI_INPUT_DOCS,
+      description: getDescription(IDB_UI_INPUT_DOCS, IDB_UI_INPUT_DOCS_MINI),
       inputSchema: {
         udid: z.string().optional(),
         operation: z.enum(['text', 'key', 'key-sequence']),
@@ -106,7 +126,7 @@ export function registerIdbTools(server: McpServer): void {
   server.registerTool(
     'idb-ui-gesture',
     {
-      description: IDB_UI_GESTURE_DOCS,
+      description: getDescription(IDB_UI_GESTURE_DOCS, IDB_UI_GESTURE_DOCS_MINI),
       inputSchema: {
         udid: z.string().optional(),
         operation: z.enum(['swipe', 'button']),
@@ -134,7 +154,7 @@ export function registerIdbTools(server: McpServer): void {
   server.registerTool(
     'idb-ui-describe',
     {
-      description: IDB_UI_DESCRIBE_DOCS,
+      description: getDescription(IDB_UI_DESCRIBE_DOCS, IDB_UI_DESCRIBE_DOCS_MINI),
       inputSchema: {
         udid: z.string().optional(),
         operation: z.enum(['all', 'point']),
@@ -152,7 +172,7 @@ export function registerIdbTools(server: McpServer): void {
   server.registerTool(
     'idb-ui-find-element',
     {
-      description: IDB_UI_FIND_ELEMENT_DOCS,
+      description: getDescription(IDB_UI_FIND_ELEMENT_DOCS, IDB_UI_FIND_ELEMENT_DOCS_MINI),
       inputSchema: {
         udid: z.string().optional(),
         query: z.string(),
@@ -166,7 +186,10 @@ export function registerIdbTools(server: McpServer): void {
   server.registerTool(
     'accessibility-quality-check',
     {
-      description: ACCESSIBILITY_QUALITY_CHECK_DOCS,
+      description: getDescription(
+        ACCESSIBILITY_QUALITY_CHECK_DOCS,
+        ACCESSIBILITY_QUALITY_CHECK_DOCS_MINI
+      ),
       inputSchema: {
         udid: z.string().optional(),
         screenContext: z.string().optional(),
@@ -180,7 +203,7 @@ export function registerIdbTools(server: McpServer): void {
   server.registerTool(
     'idb-list-apps',
     {
-      description: IDB_LIST_APPS_DOCS,
+      description: getDescription(IDB_LIST_APPS_DOCS, IDB_LIST_APPS_DOCS_MINI),
       inputSchema: {
         udid: z.string().optional(),
         filterType: z.enum(['system', 'user', 'internal']).optional(),
@@ -195,7 +218,7 @@ export function registerIdbTools(server: McpServer): void {
   server.registerTool(
     'idb-app',
     {
-      description: IDB_APP_DOCS,
+      description: getDescription(IDB_APP_DOCS, IDB_APP_DOCS_MINI),
       inputSchema: {
         operation: z.enum(['install', 'uninstall', 'launch', 'terminate']),
         udid: z.string().optional(),

--- a/src/registry/simctl.ts
+++ b/src/registry/simctl.ts
@@ -2,26 +2,41 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import { validateXcodeInstallation } from '../utils/validation.js';
-import { simctlListTool } from '../tools/simctl/list.js';
-import { SIMCTL_LIST_DOCS } from '../tools/simctl/list.js';
-import { simctlGetDetailsTool } from '../tools/simctl/get-details.js';
-import { SIMCTL_GET_DETAILS_DOCS } from '../tools/simctl/get-details.js';
-import { simctlDeviceTool } from '../tools/simctl/device/index.js';
-import { SIMCTL_DEVICE_DOCS } from '../tools/simctl/device/index.js';
-import { simctlHealthCheckTool } from '../tools/simctl/health-check.js';
-import { SIMCTL_HEALTH_CHECK_DOCS } from '../tools/simctl/health-check.js';
-import { simctlAppTool } from '../tools/simctl/app/index.js';
-import { SIMCTL_APP_DOCS } from '../tools/simctl/app/index.js';
-import { simctlGetAppContainerTool } from '../tools/simctl/get-app-container.js';
-import { SIMCTL_GET_APP_CONTAINER_DOCS } from '../tools/simctl/get-app-container.js';
-import { simctlOpenUrlTool } from '../tools/simctl/openurl.js';
-import { SIMCTL_OPENURL_DOCS } from '../tools/simctl/openurl.js';
-import { simctlIoTool } from '../tools/simctl/io.js';
-import { SIMCTL_IO_DOCS } from '../tools/simctl/io.js';
-import { simctlPushTool } from '../tools/simctl/push.js';
-import { SIMCTL_PUSH_DOCS } from '../tools/simctl/push.js';
-import { simctlScreenshotInlineTool } from '../tools/simctl/screenshot-inline.js';
-import { SIMCTL_SCREENSHOT_INLINE_DOCS } from '../tools/simctl/screenshot-inline.js';
+import { getDescription } from './types.js';
+import { simctlListTool, SIMCTL_LIST_DOCS, SIMCTL_LIST_DOCS_MINI } from '../tools/simctl/list.js';
+import {
+  simctlGetDetailsTool,
+  SIMCTL_GET_DETAILS_DOCS,
+  SIMCTL_GET_DETAILS_DOCS_MINI,
+} from '../tools/simctl/get-details.js';
+import {
+  simctlDeviceTool,
+  SIMCTL_DEVICE_DOCS,
+  SIMCTL_DEVICE_DOCS_MINI,
+} from '../tools/simctl/device/index.js';
+import {
+  simctlHealthCheckTool,
+  SIMCTL_HEALTH_CHECK_DOCS,
+  SIMCTL_HEALTH_CHECK_DOCS_MINI,
+} from '../tools/simctl/health-check.js';
+import { simctlAppTool, SIMCTL_APP_DOCS, SIMCTL_APP_DOCS_MINI } from '../tools/simctl/app/index.js';
+import {
+  simctlGetAppContainerTool,
+  SIMCTL_GET_APP_CONTAINER_DOCS,
+  SIMCTL_GET_APP_CONTAINER_DOCS_MINI,
+} from '../tools/simctl/get-app-container.js';
+import {
+  simctlOpenUrlTool,
+  SIMCTL_OPENURL_DOCS,
+  SIMCTL_OPENURL_DOCS_MINI,
+} from '../tools/simctl/openurl.js';
+import { simctlIoTool, SIMCTL_IO_DOCS, SIMCTL_IO_DOCS_MINI } from '../tools/simctl/io.js';
+import { simctlPushTool, SIMCTL_PUSH_DOCS, SIMCTL_PUSH_DOCS_MINI } from '../tools/simctl/push.js';
+import {
+  simctlScreenshotInlineTool,
+  SIMCTL_SCREENSHOT_INLINE_DOCS,
+  SIMCTL_SCREENSHOT_INLINE_DOCS_MINI,
+} from '../tools/simctl/screenshot-inline.js';
 
 const ENABLE_DEFER_LOADING = process.env.XC_MCP_DEFER_LOADING !== 'false';
 const DEFER_LOADING_CONFIG = ENABLE_DEFER_LOADING
@@ -33,7 +48,7 @@ export function registerSimctlTools(server: McpServer): void {
   server.registerTool(
     'simctl-list',
     {
-      description: SIMCTL_LIST_DOCS,
+      description: getDescription(SIMCTL_LIST_DOCS, SIMCTL_LIST_DOCS_MINI),
       inputSchema: {
         deviceType: z.string().optional(),
         runtime: z.string().optional(),
@@ -62,7 +77,7 @@ export function registerSimctlTools(server: McpServer): void {
   server.registerTool(
     'simctl-get-details',
     {
-      description: SIMCTL_GET_DETAILS_DOCS,
+      description: getDescription(SIMCTL_GET_DETAILS_DOCS, SIMCTL_GET_DETAILS_DOCS_MINI),
       inputSchema: {
         cacheId: z.string(),
         detailType: z.enum(['full-list', 'devices-only', 'runtimes-only', 'available-only']),
@@ -90,7 +105,7 @@ export function registerSimctlTools(server: McpServer): void {
   server.registerTool(
     'simctl-device',
     {
-      description: SIMCTL_DEVICE_DOCS,
+      description: getDescription(SIMCTL_DEVICE_DOCS, SIMCTL_DEVICE_DOCS_MINI),
       inputSchema: {
         operation: z.enum(['boot', 'shutdown', 'create', 'delete', 'erase', 'clone', 'rename']),
         deviceId: z.string().optional(),
@@ -122,7 +137,7 @@ export function registerSimctlTools(server: McpServer): void {
   server.registerTool(
     'simctl-health-check',
     {
-      description: SIMCTL_HEALTH_CHECK_DOCS,
+      description: getDescription(SIMCTL_HEALTH_CHECK_DOCS, SIMCTL_HEALTH_CHECK_DOCS_MINI),
       inputSchema: {},
       ...DEFER_LOADING_CONFIG,
     },
@@ -144,7 +159,7 @@ export function registerSimctlTools(server: McpServer): void {
   server.registerTool(
     'simctl-app',
     {
-      description: SIMCTL_APP_DOCS,
+      description: getDescription(SIMCTL_APP_DOCS, SIMCTL_APP_DOCS_MINI),
       inputSchema: {
         operation: z.enum(['install', 'uninstall', 'launch', 'terminate']),
         udid: z.string().optional(),
@@ -173,7 +188,10 @@ export function registerSimctlTools(server: McpServer): void {
   server.registerTool(
     'simctl-get-app-container',
     {
-      description: SIMCTL_GET_APP_CONTAINER_DOCS,
+      description: getDescription(
+        SIMCTL_GET_APP_CONTAINER_DOCS,
+        SIMCTL_GET_APP_CONTAINER_DOCS_MINI
+      ),
       inputSchema: {
         udid: z.string(),
         bundleId: z.string(),
@@ -199,7 +217,7 @@ export function registerSimctlTools(server: McpServer): void {
   server.registerTool(
     'simctl-openurl',
     {
-      description: SIMCTL_OPENURL_DOCS,
+      description: getDescription(SIMCTL_OPENURL_DOCS, SIMCTL_OPENURL_DOCS_MINI),
       inputSchema: {
         udid: z.string(),
         url: z.string(),
@@ -224,7 +242,7 @@ export function registerSimctlTools(server: McpServer): void {
   server.registerTool(
     'simctl-io',
     {
-      description: SIMCTL_IO_DOCS,
+      description: getDescription(SIMCTL_IO_DOCS, SIMCTL_IO_DOCS_MINI),
       inputSchema: {
         udid: z.string(),
         operation: z.enum(['screenshot', 'video']),
@@ -255,7 +273,7 @@ export function registerSimctlTools(server: McpServer): void {
   server.registerTool(
     'simctl-push',
     {
-      description: SIMCTL_PUSH_DOCS,
+      description: getDescription(SIMCTL_PUSH_DOCS, SIMCTL_PUSH_DOCS_MINI),
       inputSchema: {
         udid: z.string(),
         bundleId: z.string(),
@@ -283,7 +301,10 @@ export function registerSimctlTools(server: McpServer): void {
   server.registerTool(
     'screenshot',
     {
-      description: SIMCTL_SCREENSHOT_INLINE_DOCS,
+      description: getDescription(
+        SIMCTL_SCREENSHOT_INLINE_DOCS,
+        SIMCTL_SCREENSHOT_INLINE_DOCS_MINI
+      ),
       inputSchema: {
         udid: z.string().optional(),
         size: z.enum(['full', 'half', 'quarter', 'thumb']).optional(),

--- a/src/registry/system.ts
+++ b/src/registry/system.ts
@@ -1,8 +1,9 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
+import { getDescription } from './types.js';
 import { getToolDocsTool } from '../tools/get-tool-docs.js';
-import { RTFM_DOCS } from '../tools/docs-registry.js';
+import { RTFM_DOCS, RTFM_DOCS_MINI } from '../tools/docs-registry.js';
 
 const ENABLE_DEFER_LOADING = process.env.XC_MCP_DEFER_LOADING !== 'false';
 const DEFER_LOADING_CONFIG = ENABLE_DEFER_LOADING
@@ -14,7 +15,7 @@ export function registerSystemTools(server: McpServer): void {
   server.registerTool(
     'rtfm',
     {
-      description: RTFM_DOCS,
+      description: getDescription(RTFM_DOCS, RTFM_DOCS_MINI),
       inputSchema: {
         toolName: z.string().optional(),
         categoryName: z.string().optional(),

--- a/src/registry/types.ts
+++ b/src/registry/types.ts
@@ -1,4 +1,5 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { config } from '../config.js';
 
 /**
  * Shared type for all tool registration functions
@@ -6,6 +7,14 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
  * and register all tools in that category
  */
 export type ToolRegistrationFunction = (server: McpServer) => void;
+
+/**
+ * Returns the appropriate description based on CLI config
+ * Uses minimal descriptions when --mini flag is passed
+ */
+export function getDescription(full: string, mini: string): string {
+  return config.minimalDescriptions ? mini : full;
+}
 
 /**
  * Tool handler result type - all tools return this structure

--- a/src/registry/workflows.ts
+++ b/src/registry/workflows.ts
@@ -2,10 +2,17 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import { validateXcodeInstallation } from '../utils/validation.js';
-import { workflowTapElementTool } from '../tools/workflows/tap-element.js';
-import { WORKFLOW_TAP_ELEMENT_DOCS } from '../tools/workflows/tap-element.js';
-import { workflowFreshInstallTool } from '../tools/workflows/fresh-install.js';
-import { WORKFLOW_FRESH_INSTALL_DOCS } from '../tools/workflows/fresh-install.js';
+import { getDescription } from './types.js';
+import {
+  workflowTapElementTool,
+  WORKFLOW_TAP_ELEMENT_DOCS,
+  WORKFLOW_TAP_ELEMENT_DOCS_MINI,
+} from '../tools/workflows/tap-element.js';
+import {
+  workflowFreshInstallTool,
+  WORKFLOW_FRESH_INSTALL_DOCS,
+  WORKFLOW_FRESH_INSTALL_DOCS_MINI,
+} from '../tools/workflows/fresh-install.js';
 
 const ENABLE_DEFER_LOADING = process.env.XC_MCP_DEFER_LOADING !== 'false';
 const DEFER_LOADING_CONFIG = ENABLE_DEFER_LOADING
@@ -17,7 +24,7 @@ export function registerWorkflowTools(server: McpServer): void {
   server.registerTool(
     'workflow-tap-element',
     {
-      description: WORKFLOW_TAP_ELEMENT_DOCS,
+      description: getDescription(WORKFLOW_TAP_ELEMENT_DOCS, WORKFLOW_TAP_ELEMENT_DOCS_MINI),
       inputSchema: {
         elementQuery: z.string().describe('Search term for element (e.g., "Login", "Submit")'),
         inputText: z.string().optional().describe('Text to type after tapping'),
@@ -45,7 +52,7 @@ export function registerWorkflowTools(server: McpServer): void {
   server.registerTool(
     'workflow-fresh-install',
     {
-      description: WORKFLOW_FRESH_INSTALL_DOCS,
+      description: getDescription(WORKFLOW_FRESH_INSTALL_DOCS, WORKFLOW_FRESH_INSTALL_DOCS_MINI),
       inputSchema: {
         projectPath: z.string().describe('Path to .xcodeproj or .xcworkspace'),
         scheme: z.string().describe('Build scheme name'),

--- a/src/registry/xcodebuild.ts
+++ b/src/registry/xcodebuild.ts
@@ -2,18 +2,37 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import { validateXcodeInstallation } from '../utils/validation.js';
-import { xcodebuildVersionTool } from '../tools/xcodebuild/version.js';
-import { XCODEBUILD_VERSION_DOCS } from '../tools/xcodebuild/version.js';
-import { xcodebuildListTool } from '../tools/xcodebuild/list.js';
-import { XCODEBUILD_LIST_DOCS } from '../tools/xcodebuild/list.js';
-import { xcodebuildBuildTool } from '../tools/xcodebuild/build.js';
-import { XCODEBUILD_BUILD_DOCS } from '../tools/xcodebuild/build.js';
-import { xcodebuildCleanTool } from '../tools/xcodebuild/clean.js';
-import { XCODEBUILD_CLEAN_DOCS } from '../tools/xcodebuild/clean.js';
-import { xcodebuildTestTool } from '../tools/xcodebuild/xcodebuild-test.js';
-import { XCODEBUILD_TEST_DOCS } from '../tools/xcodebuild/xcodebuild-test.js';
-import { xcodebuildGetDetailsTool } from '../tools/xcodebuild/get-details.js';
-import { XCODEBUILD_GET_DETAILS_DOCS } from '../tools/xcodebuild/get-details.js';
+import { getDescription } from './types.js';
+import {
+  xcodebuildVersionTool,
+  XCODEBUILD_VERSION_DOCS,
+  XCODEBUILD_VERSION_DOCS_MINI,
+} from '../tools/xcodebuild/version.js';
+import {
+  xcodebuildListTool,
+  XCODEBUILD_LIST_DOCS,
+  XCODEBUILD_LIST_DOCS_MINI,
+} from '../tools/xcodebuild/list.js';
+import {
+  xcodebuildBuildTool,
+  XCODEBUILD_BUILD_DOCS,
+  XCODEBUILD_BUILD_DOCS_MINI,
+} from '../tools/xcodebuild/build.js';
+import {
+  xcodebuildCleanTool,
+  XCODEBUILD_CLEAN_DOCS,
+  XCODEBUILD_CLEAN_DOCS_MINI,
+} from '../tools/xcodebuild/clean.js';
+import {
+  xcodebuildTestTool,
+  XCODEBUILD_TEST_DOCS,
+  XCODEBUILD_TEST_DOCS_MINI,
+} from '../tools/xcodebuild/xcodebuild-test.js';
+import {
+  xcodebuildGetDetailsTool,
+  XCODEBUILD_GET_DETAILS_DOCS,
+  XCODEBUILD_GET_DETAILS_DOCS_MINI,
+} from '../tools/xcodebuild/get-details.js';
 
 const ENABLE_DEFER_LOADING = process.env.XC_MCP_DEFER_LOADING !== 'false';
 const DEFER_LOADING_CONFIG = ENABLE_DEFER_LOADING
@@ -25,7 +44,7 @@ export function registerXcodebuildTools(server: McpServer): void {
   server.registerTool(
     'xcodebuild-version',
     {
-      description: XCODEBUILD_VERSION_DOCS,
+      description: getDescription(XCODEBUILD_VERSION_DOCS, XCODEBUILD_VERSION_DOCS_MINI),
       inputSchema: {
         sdk: z.string().optional(),
         outputFormat: z.enum(['json', 'text']).default('json'),
@@ -50,7 +69,7 @@ export function registerXcodebuildTools(server: McpServer): void {
   server.registerTool(
     'xcodebuild-list',
     {
-      description: XCODEBUILD_LIST_DOCS,
+      description: getDescription(XCODEBUILD_LIST_DOCS, XCODEBUILD_LIST_DOCS_MINI),
       inputSchema: {
         projectPath: z.string(),
         outputFormat: z.enum(['json', 'text']).default('json'),
@@ -75,7 +94,7 @@ export function registerXcodebuildTools(server: McpServer): void {
   server.registerTool(
     'xcodebuild-build',
     {
-      description: XCODEBUILD_BUILD_DOCS,
+      description: getDescription(XCODEBUILD_BUILD_DOCS, XCODEBUILD_BUILD_DOCS_MINI),
       inputSchema: {
         projectPath: z.string(),
         scheme: z.string(),
@@ -104,7 +123,7 @@ export function registerXcodebuildTools(server: McpServer): void {
   server.registerTool(
     'xcodebuild-clean',
     {
-      description: XCODEBUILD_CLEAN_DOCS,
+      description: getDescription(XCODEBUILD_CLEAN_DOCS, XCODEBUILD_CLEAN_DOCS_MINI),
       inputSchema: {
         projectPath: z.string(),
         scheme: z.string(),
@@ -130,7 +149,7 @@ export function registerXcodebuildTools(server: McpServer): void {
   server.registerTool(
     'xcodebuild-test',
     {
-      description: XCODEBUILD_TEST_DOCS,
+      description: getDescription(XCODEBUILD_TEST_DOCS, XCODEBUILD_TEST_DOCS_MINI),
       inputSchema: {
         projectPath: z.string(),
         scheme: z.string(),
@@ -163,7 +182,7 @@ export function registerXcodebuildTools(server: McpServer): void {
   server.registerTool(
     'xcodebuild-get-details',
     {
-      description: XCODEBUILD_GET_DETAILS_DOCS,
+      description: getDescription(XCODEBUILD_GET_DETAILS_DOCS, XCODEBUILD_GET_DETAILS_DOCS_MINI),
       inputSchema: {
         buildId: z.string(),
         detailType: z.enum([

--- a/src/tools/cache/index.ts
+++ b/src/tools/cache/index.ts
@@ -197,3 +197,6 @@ await cacheTool({
 - \`xcodebuild-get-details\`: Retrieve cached build output
 - \`simctl-get-details\`: Retrieve cached simulator details
 `;
+
+export const CACHE_DOCS_MINI =
+  'Manage cache (stats/config/clear). Use rtfm({ toolName: "cache" }) for docs.';

--- a/src/tools/docs-registry.ts
+++ b/src/tools/docs-registry.ts
@@ -396,6 +396,11 @@ rtfm({ toolName: "simctl" })  // Shows simctl-* suggestions
 - The TOOL_DOCS registry is automatically updated when tools are added/removed
 `;
 
+export const RTFM_DOCS_MINI = 'Get tool documentation. Use rtfm({ toolName: "rtfm" }) for docs.';
+
+export const SCREENSHOT_SAVE_DOCS_MINI =
+  'Save screenshot to file. Use rtfm({ toolName: "screenshot-save" }) for docs.';
+
 /**
  * Tool categories for progressive discovery
  */

--- a/src/tools/idb/accessibility-quality-check.ts
+++ b/src/tools/idb/accessibility-quality-check.ts
@@ -141,6 +141,10 @@ const assessment = await accessibilityQualityCheckTool({
 - Saves tokens by preventing unnecessary screenshots
 - Identifies when UI has minimal accessibility support
 `;
+
+export const ACCESSIBILITY_QUALITY_CHECK_DOCS_MINI =
+  'Assess accessibility tree quality. Use rtfm({ toolName: "accessibility-quality-check" }) for docs.';
+
 export async function accessibilityQualityCheckTool(args: AccessibilityQualityCheckArgs) {
   const { udid, screenContext } = args;
 

--- a/src/tools/idb/app/index.ts
+++ b/src/tools/idb/app/index.ts
@@ -203,3 +203,6 @@ await idbAppTool({
 - \`idb-ui-tap\`, \`idb-ui-input\`, \`idb-ui-gesture\`: UI automation
 - \`simctl-app\`: Simctl-based app management
 `;
+
+export const IDB_APP_DOCS_MINI =
+  'Manage IDB apps (install/launch/etc). Use rtfm({ toolName: "idb-app" }) for docs.';

--- a/src/tools/idb/list-apps.ts
+++ b/src/tools/idb/list-apps.ts
@@ -393,3 +393,6 @@ const all = await idbListAppsTool({
 - Running status helps identify active processes for UI automation
 - Debuggable status indicates if debugger can be attached
 `;
+
+export const IDB_LIST_APPS_DOCS_MINI =
+  'List installed apps with bundle IDs. Use rtfm({ toolName: "idb-list-apps" }) for docs.';

--- a/src/tools/idb/targets/index.ts
+++ b/src/tools/idb/targets/index.ts
@@ -190,3 +190,6 @@ await idbTargetsToolUnified({
 - \`idb-app\`: App management on IDB targets
 - \`idb-ui-tap\`, \`idb-ui-input\`, \`idb-ui-gesture\`: UI automation on targets
 `;
+
+export const IDB_TARGETS_DOCS_MINI =
+  'Manage IDB targets (list/describe/connect). Use rtfm({ toolName: "idb-targets" }) for docs.';

--- a/src/tools/idb/ui-describe.ts
+++ b/src/tools/idb/ui-describe.ts
@@ -792,3 +792,6 @@ const element = await idbUiDescribeTool({
 - idb-ui-find-element: Semantic element search by label/identifier
 - accessibility-quality-check: Quick assessment before choosing approach
 `;
+
+export const IDB_UI_DESCRIBE_DOCS_MINI =
+  'Query UI accessibility tree. Use rtfm({ toolName: "idb-ui-describe" }) for docs.';

--- a/src/tools/idb/ui-find-element.ts
+++ b/src/tools/idb/ui-find-element.ts
@@ -125,6 +125,10 @@ const search = await idbUiFindElementTool({
 - Much faster than visual analysis (~80ms vs 2000ms for screenshot)
 - 5-6x cheaper token cost (~40 tokens vs ~170 for screenshot)
 `;
+
+export const IDB_UI_FIND_ELEMENT_DOCS_MINI =
+  'Find UI elements by semantic search. Use rtfm({ toolName: "idb-ui-find-element" }) for docs.';
+
 export async function idbUiFindElementTool(args: IdbUiFindElementArgs) {
   const { udid, query } = args;
 

--- a/src/tools/idb/ui-gesture.ts
+++ b/src/tools/idb/ui-gesture.ts
@@ -641,3 +641,6 @@ await idbUiGestureTool({ operation: 'button', buttonType: 'HOME' });
 - idb-ui-tap: For precise element tapping
 - idb-ui-describe: Find element coordinates
 `;
+
+export const IDB_UI_GESTURE_DOCS_MINI =
+  'Perform gestures and button presses. Use rtfm({ toolName: "idb-ui-gesture" }) for docs.';

--- a/src/tools/idb/ui-input.ts
+++ b/src/tools/idb/ui-input.ts
@@ -421,3 +421,6 @@ await idbUiInputTool({ operation: 'key', key: 'return' });
 - idb-ui-tap: Tap to focus text fields before typing
 - idb-ui-describe: Find text field coordinates
 `;
+
+export const IDB_UI_INPUT_DOCS_MINI =
+  'Input text and keyboard commands. Use rtfm({ toolName: "idb-ui-input" }) for docs.';

--- a/src/tools/idb/ui-tap.ts
+++ b/src/tools/idb/ui-tap.ts
@@ -404,3 +404,6 @@ const result = await idbUiTapTool({
 - screenshot: Capture screenshot to identify tap targets
 - idb-ui-gesture: For swipes and hardware buttons
 `;
+
+export const IDB_UI_TAP_DOCS_MINI =
+  'Tap at coordinates on iOS screen. Use rtfm({ toolName: "idb-ui-tap" }) for docs.';

--- a/src/tools/persistence/index.ts
+++ b/src/tools/persistence/index.ts
@@ -166,3 +166,6 @@ Persistence status (enabled/disabled), cache directory path, and optional storag
 
 - \`cache\`: Cache management and configuration
 `;
+
+export const PERSISTENCE_DOCS_MINI =
+  'Manage cache persistence (enable/disable/status). Use rtfm({ toolName: "persistence" }) for docs.';

--- a/src/tools/simctl/app/index.ts
+++ b/src/tools/simctl/app/index.ts
@@ -204,3 +204,6 @@ await simctlAppTool({
 - \`simctl-list\`: Discover simulators and their UDIDs
 - \`idb-app\`: IDB-based app management
 `;
+
+export const SIMCTL_APP_DOCS_MINI =
+  'Manage apps on simulators (install/launch/etc). Use rtfm({ toolName: "simctl-app" }) for docs.';

--- a/src/tools/simctl/device/index.ts
+++ b/src/tools/simctl/device/index.ts
@@ -298,3 +298,6 @@ await simctlDeviceTool({ operation: 'rename', deviceId: 'ABC-123-DEF', newName: 
 - \`simctl-app\`: Install and launch apps on devices
 - \`simctl-io\`: Take screenshots and record videos
 `;
+
+export const SIMCTL_DEVICE_DOCS_MINI =
+  'Manage simulator lifecycle (boot/shutdown/create/etc). Use rtfm({ toolName: "simctl-device" }) for docs.';

--- a/src/tools/simctl/get-app-container.ts
+++ b/src/tools/simctl/get-app-container.ts
@@ -255,3 +255,6 @@ await simctlGetAppContainerTool({
 4. **Inspect specific file**: \`cat "<container-path>/Documents/data.json"\`
 `;
 
+export const SIMCTL_GET_APP_CONTAINER_DOCS_MINI =
+  'Get app container path on simulator. Use rtfm({ toolName: "simctl-get-app-container" }) for docs.';
+

--- a/src/tools/simctl/get-details.ts
+++ b/src/tools/simctl/get-details.ts
@@ -311,3 +311,6 @@ Retrieves on-demand access to full simulator and runtime lists that were cached 
 - Cache IDs expire after 1 hour
 - Use for discovering available devices and runtimes
 `;
+
+export const SIMCTL_GET_DETAILS_DOCS_MINI =
+  'Get simulator details from cache. Use rtfm({ toolName: "simctl-get-details" }) for docs.';

--- a/src/tools/simctl/health-check.ts
+++ b/src/tools/simctl/health-check.ts
@@ -261,7 +261,7 @@ async function checkDiskSpace() {
       name: 'Disk Space',
       status: 'Unable to determine (continue with caution)',
     };
-  } catch (error) {
+  } catch {
     return {
       pass: true,
       name: 'Disk Space',
@@ -351,3 +351,6 @@ if (!health.healthy) {
 - Perfect for troubleshooting when operations fail unexpectedly
 - Use before CI/CD pipeline execution to ensure environment health
 `;
+
+export const SIMCTL_HEALTH_CHECK_DOCS_MINI =
+  'Check simulator environment health. Use rtfm({ toolName: "simctl-health-check" }) for docs.';

--- a/src/tools/simctl/io.ts
+++ b/src/tools/simctl/io.ts
@@ -453,3 +453,6 @@ This enables accurate element tapping even with optimized screenshots.
 3. **Analyze with LLM**: Use optimized size for token-efficient analysis
 4. **Use coordinates**: Apply transform to map screenshot coords to device
 `;
+
+export const SIMCTL_IO_DOCS_MINI =
+  'Capture screenshots or record video. Use rtfm({ toolName: "simctl-io" }) for docs.';

--- a/src/tools/simctl/list.ts
+++ b/src/tools/simctl/list.ts
@@ -338,3 +338,6 @@ await simctlListTool({ runtime: "17.0" });
 - Smart filtering by device type, runtime, and availability
 - Essential: Use this instead of 'xcrun simctl list' for better performance
 `;
+
+export const SIMCTL_LIST_DOCS_MINI =
+  'List iOS simulators with caching. Use rtfm({ toolName: "simctl-list" }) for docs.';

--- a/src/tools/simctl/openurl.ts
+++ b/src/tools/simctl/openurl.ts
@@ -249,3 +249,6 @@ await simctlOpenUrlTool({
 - **State preservation**: Verify app state is maintained after URL handling
 `;
 
+export const SIMCTL_OPENURL_DOCS_MINI =
+  'Open URLs and deep links on simulator. Use rtfm({ toolName: "simctl-openurl" }) for docs.';
+

--- a/src/tools/simctl/push.ts
+++ b/src/tools/simctl/push.ts
@@ -342,3 +342,6 @@ This enables agents to track push notification tests and verify expected behavio
 - **Notification grouping**: Test thread-id for notification grouping
 `;
 
+export const SIMCTL_PUSH_DOCS_MINI =
+  'Send push notifications to simulator. Use rtfm({ toolName: "simctl-push" }) for docs.';
+

--- a/src/tools/simctl/screenshot-inline.ts
+++ b/src/tools/simctl/screenshot-inline.ts
@@ -662,3 +662,6 @@ Token counts are estimates based on Claude's image processing (170 tokens per 51
 | Use case | MCP responses | File storage |
 | Token usage | Optimized | Depends on size |
 `;
+
+export const SIMCTL_SCREENSHOT_INLINE_DOCS_MINI =
+  'Capture screenshot with base64 encoding. Use rtfm({ toolName: "screenshot" }) for docs.';

--- a/src/tools/workflows/fresh-install.ts
+++ b/src/tools/workflows/fresh-install.ts
@@ -520,3 +520,6 @@ Targets specific simulator with custom launch configuration.
 - Build artifacts are located automatically
 - Bundle ID is discovered from build settings
 `;
+
+export const WORKFLOW_FRESH_INSTALL_DOCS_MINI =
+  'Build, install and launch app on fresh simulator. Use rtfm({ toolName: "workflow-fresh-install" }) for docs.';

--- a/src/tools/workflows/tap-element.ts
+++ b/src/tools/workflows/tap-element.ts
@@ -485,3 +485,6 @@ Taps Submit button and captures verification screenshot.
 - Element matching uses partial, case-insensitive search
 - Small delay between tap and input for keyboard appearance
 `;
+
+export const WORKFLOW_TAP_ELEMENT_DOCS_MINI =
+  'Find and tap elements by name. Use rtfm({ toolName: "workflow-tap-element" }) for docs.';

--- a/src/tools/xcodebuild/build.ts
+++ b/src/tools/xcodebuild/build.ts
@@ -426,3 +426,6 @@ const release = await xcodebuildBuildTool({
 - xcodebuild-clean: Clean build artifacts
 - xcodebuild-get-details: Get full build logs (use with buildId)
 `;
+
+export const XCODEBUILD_BUILD_DOCS_MINI =
+  'Build Xcode projects with smart defaults. Use rtfm({ toolName: "xcodebuild-build" }) for docs.';

--- a/src/tools/xcodebuild/clean.ts
+++ b/src/tools/xcodebuild/clean.ts
@@ -1,6 +1,6 @@
 import { validateProjectPath, validateScheme } from '../../utils/validation.js';
 import { executeCommand, buildXcodebuildCommand } from '../../utils/command.js';
-import type { ToolResult } from '../../types/xcode.js';
+import type { ToolResult as _ToolResult } from '../../types/xcode.js';
 import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
 
 interface CleanToolArgs {
@@ -165,3 +165,6 @@ const cleanRelease = await xcodebuildCleanTool({
 - xcodebuild-build: Build after cleaning
 - xcodebuild-list: Discover available schemes
 `;
+
+export const XCODEBUILD_CLEAN_DOCS_MINI =
+  'Clean build artifacts. Use rtfm({ toolName: "xcodebuild-clean" }) for docs.';

--- a/src/tools/xcodebuild/get-details.ts
+++ b/src/tools/xcodebuild/get-details.ts
@@ -84,7 +84,7 @@ export async function xcodebuildGetDetailsTool(args: any) {
     let responseText: string;
 
     switch (detailType) {
-      case 'full-log':
+      case 'full-log': {
         const fullLog =
           cached.fullOutput + (cached.stderr ? '\n--- STDERR ---\n' + cached.stderr : '');
         const lines = fullLog.split('\n');
@@ -114,8 +114,9 @@ export async function xcodebuildGetDetailsTool(args: any) {
           );
         }
         break;
+      }
 
-      case 'errors-only':
+      case 'errors-only': {
         const allOutput = cached.fullOutput + '\n' + cached.stderr;
         const errorLines = allOutput
           .split('\n')
@@ -137,8 +138,9 @@ export async function xcodebuildGetDetailsTool(args: any) {
           2
         );
         break;
+      }
 
-      case 'warnings-only':
+      case 'warnings-only': {
         const warningLines = (cached.fullOutput + '\n' + cached.stderr)
           .split('\n')
           .filter(line => line.includes('warning:'));
@@ -154,6 +156,7 @@ export async function xcodebuildGetDetailsTool(args: any) {
           2
         );
         break;
+      }
 
       case 'summary':
         responseText = JSON.stringify(
@@ -277,3 +280,6 @@ Provides on-demand access to full build and test logs that were cached during xc
 - Cache IDs expire after 30 minutes
 - Use for debugging build failures and test issues
 `;
+
+export const XCODEBUILD_GET_DETAILS_DOCS_MINI =
+  'Get build/test logs from cache. Use rtfm({ toolName: "xcodebuild-get-details" }) for docs.';

--- a/src/tools/xcodebuild/list.ts
+++ b/src/tools/xcodebuild/list.ts
@@ -159,3 +159,6 @@ const textInfo = await xcodebuildListTool({
 - xcodebuild-build: Build discovered schemes
 - xcodebuild-test: Test discovered schemes
 `;
+
+export const XCODEBUILD_LIST_DOCS_MINI =
+  'List project schemes and targets. Use rtfm({ toolName: "xcodebuild-list" }) for docs.';

--- a/src/tools/xcodebuild/version.ts
+++ b/src/tools/xcodebuild/version.ts
@@ -1,5 +1,5 @@
 import { executeCommand } from '../../utils/command.js';
-import type { ToolResult, OutputFormat } from '../../types/xcode.js';
+import type { ToolResult as _ToolResult, OutputFormat } from '../../types/xcode.js';
 import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
 
 interface VersionToolArgs {
@@ -76,7 +76,7 @@ export async function xcodebuildVersionTool(args: any) {
         // Parse and format JSON response
         const versionInfo = JSON.parse(result.stdout);
         responseText = JSON.stringify(versionInfo, null, 2);
-      } catch (_parseError) {
+      } catch {
         // If JSON parsing fails, the output might be plain text
         // This can happen with older Xcode versions
         responseText = JSON.stringify(
@@ -154,3 +154,6 @@ const sdkInfo = await xcodebuildVersionTool({ sdk: "iphoneos" });
 - xcodebuild-showsdks: Show all available SDKs
 - xcodebuild-list: List project information
 `;
+
+export const XCODEBUILD_VERSION_DOCS_MINI =
+  'Get Xcode and SDK version info. Use rtfm({ toolName: "xcodebuild-version" }) for docs.';

--- a/src/tools/xcodebuild/xcodebuild-test.ts
+++ b/src/tools/xcodebuild/xcodebuild-test.ts
@@ -693,3 +693,6 @@ const quick = await xcodebuildTestTool({
 - xcodebuild-get-details: Get full test logs (use with testId)
 - simctl-list: See available test simulators
 `;
+
+export const XCODEBUILD_TEST_DOCS_MINI =
+  'Run Xcode tests with filtering. Use rtfm({ toolName: "xcodebuild-test" }) for docs.';


### PR DESCRIPTION
## Summary

- Adds `--mini` CLI argument that toggles between verbose (~18.7k tokens) and minimal (~540 tokens) tool descriptions
- Achieves ~97% token reduction for clients like Claude Code that don't support MCP `defer_loading`
- Mini descriptions follow "one-liner + rtfm hint" format, co-located with each tool file
- Full descriptions remain the default for backwards compatibility

## Changes

- Add `src/config.ts` for CLI argument parsing
- Add `getDescription()` helper to `src/registry/types.ts`
- Add `*_DOCS_MINI` exports to all 30 tool files
- Update all 6 registry files to use `getDescription()`
- Update README with Minimal Mode documentation
- Fix pre-existing lint error (unused catch variable)

## Usage

```json
{
  "mcpServers": {
    "xc-mcp": {
      "command": "npx",
      "args": ["-y", "xc-mcp", "--mini"]
    }
  }
}
```

## Test plan

- [x] Build succeeds (`npm run build`)
- [x] Tests pass (`npm test`)
- [x] Default mode works: `XC-MCP v3.0.1: descriptions=full, defer_loading=enabled`
- [x] Mini mode works: `XC-MCP v3.0.1: descriptions=mini, defer_loading=enabled`

🤖 Generated with [Claude Code](https://claude.com/claude-code)