### PR TITLE
feat: Add --build-only CLI flag for reduced tool loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,19 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 ```
 The `--mini` flag reduces tool descriptions from ~18.7k tokens to ~540 tokens (~97% reduction). Use `rtfm` for full documentation on-demand.
 
+**Build-Only Mode** (for build-focused workflows without UI automation):
+```json
+{
+  "mcpServers": {
+    "xc-mcp": {
+      "command": "npx",
+      "args": ["-y", "xc-mcp", "--build-only"]
+    }
+  }
+}
+```
+The `--build-only` flag loads only 11 tools (vs 30): xcodebuild tools, simctl-list, cache, and system tools. Excludes IDB/UI automation and workflow tools. Combine with `--mini` for maximum reduction: `["--mini", "--build-only"]`.
+
 ---
 
 ## Token Optimization Architecture

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,6 +8,8 @@ export interface MCPConfig {
   minimalDescriptions: boolean;
   /** Enable defer_loading hint for MCP clients that support it */
   deferLoading: boolean;
+  /** Load only build-related tools (xcodebuild, simctl-list, cache, system) */
+  buildOnly: boolean;
 }
 
 function parseArgs(): MCPConfig {
@@ -15,6 +17,7 @@ function parseArgs(): MCPConfig {
   return {
     minimalDescriptions: args.includes('--mini') || args.includes('-m'),
     deferLoading: process.env.XC_MCP_DEFER_LOADING !== 'false',
+    buildOnly: args.includes('--build-only') || args.includes('-b'),
   };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ class XcodeCLIMCPServer {
     this.server = new McpServer(
       {
         name: 'xc-mcp',
-        version: '3.0.1',
+        version: '3.1.0',
         description:
           'Wraps xcodebuild, simctl, and IDB with intelligent caching, for efficient iOS development. The RTFM tool can be called with any of the tool names to return further documentation if required. Tool descriptions are intentionally minimal to reduce MCP context usage.',
       },
@@ -98,7 +98,7 @@ Call \`rtfm\` with tool name for full documentation. Example: \`rtfm({ toolName:
     registerAllTools(this.server);
 
     console.error(
-      `XC-MCP v3.0.1: descriptions=${config.minimalDescriptions ? 'mini' : 'full'}, defer_loading=${config.deferLoading ? 'enabled' : 'disabled'}`
+      `XC-MCP v3.1.0: descriptions=${config.minimalDescriptions ? 'mini' : 'full'}, defer_loading=${config.deferLoading ? 'enabled' : 'disabled'}, build_only=${config.buildOnly ? 'enabled' : 'disabled'}`
     );
   }
 

--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -1,6 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { config } from '../config.js';
 import { registerXcodebuildTools } from './xcodebuild.js';
-import { registerSimctlTools } from './simctl.js';
+import { registerSimctlListTool, registerSimctlTools } from './simctl.js';
 import { registerIdbTools } from './idb.js';
 import { registerCacheTools } from './cache.js';
 import { registerWorkflowTools } from './workflows.js';
@@ -9,12 +10,24 @@ import { registerSystemTools } from './system.js';
 /**
  * Register all XC-MCP tools with the MCP server
  * Organizes tool registration into modular files by category
+ *
+ * When --build-only flag is set, only registers:
+ * - xcodebuild tools (build, test, clean, list, version, get-details)
+ * - simctl-list (for simulator discovery during builds)
+ * - cache tools (cache, persistence)
+ * - system tools (rtfm, tool-search)
  */
 export function registerAllTools(server: McpServer): void {
+  // Always register build-related tools
   registerXcodebuildTools(server);
-  registerSimctlTools(server);
-  registerIdbTools(server);
+  registerSimctlListTool(server);
   registerCacheTools(server);
-  registerWorkflowTools(server);
   registerSystemTools(server);
+
+  // Only register full toolset when NOT in build-only mode
+  if (!config.buildOnly) {
+    registerSimctlTools(server);
+    registerIdbTools(server);
+    registerWorkflowTools(server);
+  }
 }

--- a/src/registry/simctl.ts
+++ b/src/registry/simctl.ts
@@ -43,8 +43,10 @@ const DEFER_LOADING_CONFIG = ENABLE_DEFER_LOADING
   ? ({ defer_loading: true } as Record<string, unknown>)
   : {};
 
-export function registerSimctlTools(server: McpServer): void {
-  // simctl-list
+/**
+ * Register only simctl-list tool (used in build-only mode for simulator discovery)
+ */
+export function registerSimctlListTool(server: McpServer): void {
   server.registerTool(
     'simctl-list',
     {
@@ -72,7 +74,12 @@ export function registerSimctlTools(server: McpServer): void {
       }
     }
   );
+}
 
+/**
+ * Register all simctl tools except simctl-list (which is registered separately)
+ */
+export function registerSimctlTools(server: McpServer): void {
   // simctl-get-details
   server.registerTool(
     'simctl-get-details',


### PR DESCRIPTION
## Summary

- Add `--build-only` (or `-b`) CLI flag that loads only 11 build-focused tools instead of the full 30 tool set
- Tools included: xcodebuild (6), simctl-list (1), system tools (4)
- Excludes IDB/UI automation and workflow tools for build-focused workflows
- Can be combined with `--mini` for maximum token reduction

## Usage

```json
{
  "mcpServers": {
    "xc-mcp": {
      "command": "npx",
      "args": ["-y", "xc-mcp", "--build-only"]
    }
  }
}
```

## Test plan

- [x] Build passes
- [x] All 1186 tests pass
- [x] `--build-only` flag shows `build_only=enabled` in startup
- [x] `-b` short flag works
- [x] Combined `--mini --build-only` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)