### PR TITLE
Fix: destination parameter bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xc-mcp",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xc-mcp",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.17.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xc-mcp",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xc-mcp",
-      "version": "3.2.1",
+      "version": "3.2.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.17.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,6 +75,7 @@
       "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -1685,6 +1686,7 @@
       "integrity": "sha512-jCzKdm/QK0Kg4V4IK/oMlRZlY+QOcdjv89U2NgKHZk1CYTj82/RVSx1mV/0gqCVMJ/DA+Zf/S4NBWNF8GQ+eqQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.48.0",
         "@typescript-eslint/types": "8.48.0",
@@ -2178,6 +2180,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2446,6 +2449,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -3093,6 +3097,7 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3153,6 +3158,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -3456,6 +3462,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
       "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.0",
@@ -4261,6 +4268,7 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -5780,6 +5788,7 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -6635,6 +6644,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6814,6 +6824,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7262,6 +7273,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,7 +75,6 @@
       "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -1686,7 +1685,6 @@
       "integrity": "sha512-jCzKdm/QK0Kg4V4IK/oMlRZlY+QOcdjv89U2NgKHZk1CYTj82/RVSx1mV/0gqCVMJ/DA+Zf/S4NBWNF8GQ+eqQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.48.0",
         "@typescript-eslint/types": "8.48.0",
@@ -2180,7 +2178,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2449,7 +2446,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -3097,7 +3093,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3158,7 +3153,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -3462,7 +3456,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
       "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.0",
@@ -4268,7 +4261,6 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -5788,7 +5780,6 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -6644,7 +6635,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6824,7 +6814,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7273,7 +7262,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.2.0",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.17.1",
+        "@modelcontextprotocol/sdk": "1.17.1",
         "@types/node": "^24.1.0"
       },
       "bin": {
@@ -1423,9 +1423,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.17.4",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.17.4.tgz",
-      "integrity": "sha512-zq24hfuAmmlNZvik0FLI58uE5sriN0WWsQzIlYnzSuKDAHFqJtBFrl/LfB1NLgJT5Y7dEBzaX4yAKqOPrcetaw==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.17.1.tgz",
+      "integrity": "sha512-CPle1OQehbWqd25La9Ack5B07StKIxh4+Bf19qnpZKJC1oI22Y0czZHbifjw1UoczIfKBwBDAp/dFxvHG13B5A==",
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xc-mcp",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "MCP server that wraps Xcode command-line tools for iOS/macOS development workflows",
   "author": "Conor Luddy",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "package.json"
   ],
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.17.1",
+    "@modelcontextprotocol/sdk": "1.17.1",
     "@types/node": "^24.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xc-mcp",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "MCP server that wraps Xcode command-line tools for iOS/macOS development workflows",
   "author": "Conor Luddy",
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ class XcodeCLIMCPServer {
     this.server = new McpServer(
       {
         name: 'xc-mcp',
-        version: '3.2.0',
+        version: '3.2.1',
         description:
           'Wraps xcodebuild, simctl, and IDB with intelligent caching, for efficient iOS development. The RTFM tool can be called with any of the tool names to return further documentation if required. Tool descriptions are intentionally minimal to reduce MCP context usage.',
       },

--- a/src/tools/xcodebuild/build.ts
+++ b/src/tools/xcodebuild/build.ts
@@ -220,6 +220,7 @@ export async function xcodebuildBuildTool(args: any) {
       guidance: summary.success
         ? [
             `Build completed successfully in ${duration}ms`,
+            ...(summary.warningCount > 0 ? [`⚠️ ${summary.warningCount} warning(s) detected`] : []),
             ...(usedSmartDestination ? [`Used smart simulator: ${finalConfig.destination}`] : []),
             ...(hasPreferredConfig ? [`Applied cached project preferences`] : []),
             `Use 'xcodebuild-get-details' with buildId '${cacheId}' for full logs`,

--- a/src/tools/xcodebuild/build.ts
+++ b/src/tools/xcodebuild/build.ts
@@ -196,11 +196,17 @@ export async function xcodebuildBuildTool(args: any) {
       }
     }
 
+    // Destructure errors/warnings from summary for top-level placement
+    const { errors, warnings, ...summaryRest } = summary;
+
     const responseData = {
       buildId: cacheId,
       success: summary.success,
+      // Errors and warnings at top level for immediate visibility
+      errors: errors.length > 0 ? errors : undefined,
+      warnings: warnings.length > 0 ? warnings : undefined,
       summary: {
-        ...summary,
+        ...summaryRest,
         scheme: finalConfig.scheme,
         configuration: finalConfig.configuration,
         destination: finalConfig.destination,

--- a/src/utils/response-cache.ts
+++ b/src/utils/response-cache.ts
@@ -193,6 +193,9 @@ export function extractBuildSummary(output: string, stderr: string, exitCode: nu
     hasErrors: errors.length > 0,
     hasWarnings: warnings.length > 0,
     firstError: errors[0]?.trim(),
+    // Include first 10 errors and warnings for immediate visibility
+    errors: errors.slice(0, 10).map(e => e.trim()),
+    warnings: warnings.slice(0, 10).map(w => w.trim()),
     buildSizeBytes: output.length + stderr.length,
   };
 }

--- a/tests/__tests__/tools/xcodebuild-build.test.ts
+++ b/tests/__tests__/tools/xcodebuild-build.test.ts
@@ -1,0 +1,251 @@
+import { jest } from '@jest/globals';
+
+// Shared mocks
+const mockExecuteCommandStreaming = jest.fn(async (..._args: any[]) => undefined as any);
+const mockBuildXcodebuildCommand = jest.fn((..._args: any[]) => '');
+const mockExtractBuildSummary = jest.fn((..._args: any[]) => undefined as any);
+const mockResponseCacheStore = jest.fn((..._args: any[]) => undefined as any);
+const mockGetPreferredBuildConfig = jest.fn(async (..._args: any[]) => undefined as any);
+const mockRecordBuildResult = jest.fn((..._args: any[]) => undefined as any);
+const mockGetPreferredSimulator = jest.fn(async (..._args: any[]) => undefined as any);
+const mockGetSimulatorList = jest.fn(async (..._args: any[]) => undefined as any);
+const mockRecordSimulatorUsage = jest.fn((..._args: any[]) => undefined as any);
+const mockCreateConfigManager = jest.fn((..._args: any[]) => undefined as any);
+
+jest.mock('../../../src/utils/validation.js', () => ({
+  validateProjectPath: jest.fn(async () => undefined),
+  validateScheme: jest.fn(),
+}));
+
+jest.mock('../../../src/utils/command.js', () => ({
+  executeCommandStreaming: (...args: any[]) => mockExecuteCommandStreaming(...args),
+  buildXcodebuildCommand: (...args: any[]) => mockBuildXcodebuildCommand(...args),
+}));
+
+jest.mock('../../../src/utils/response-cache.js', () => ({
+  extractBuildSummary: (...args: any[]) => mockExtractBuildSummary(...args),
+  responseCache: {
+    store: (...args: any[]) => mockResponseCacheStore(...args),
+  },
+}));
+
+jest.mock('../../../src/state/project-cache.js', () => ({
+  projectCache: {
+    getPreferredBuildConfig: (...args: any[]) => mockGetPreferredBuildConfig(...args),
+    recordBuildResult: (...args: any[]) => mockRecordBuildResult(...args),
+  },
+}));
+
+jest.mock('../../../src/state/simulator-cache.js', () => ({
+  simulatorCache: {
+    getPreferredSimulator: (...args: any[]) => mockGetPreferredSimulator(...args),
+    getSimulatorList: (...args: any[]) => mockGetSimulatorList(...args),
+    recordSimulatorUsage: (...args: any[]) => mockRecordSimulatorUsage(...args),
+  },
+}));
+
+jest.mock('../../../src/utils/config.js', () => ({
+  createConfigManager: (...args: any[]) => mockCreateConfigManager(...args),
+}));
+
+describe('xcodebuild-build parameter resolution', () => {
+  const projectPath = 'SpaceTime.xcodeproj';
+  const scheme = 'SpaceTime';
+
+  const successResult = {
+    stdout: '',
+    stderr: '',
+    code: 0,
+    timedOut: false,
+  };
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+
+    mockBuildXcodebuildCommand.mockImplementation((action: string, path: string, opts: any) =>
+      JSON.stringify({ action, path, opts })
+    );
+    mockExecuteCommandStreaming.mockResolvedValue(successResult);
+    mockExtractBuildSummary.mockReturnValue({
+      success: true,
+      errors: [],
+      warnings: [],
+      errorCount: 0,
+      warningCount: 0,
+      buildSizeBytes: 0,
+    });
+    mockResponseCacheStore.mockReturnValue('build-id');
+    mockCreateConfigManager.mockReturnValue({
+      recordSuccessfulBuild: jest.fn(),
+    });
+  });
+
+  async function loadTool() {
+    const mod = await import('../../../src/tools/xcodebuild/build.js');
+    return mod.xcodebuildBuildTool;
+  }
+
+  function responseFrom(result: any) {
+    return JSON.parse(result.content[0].text);
+  }
+
+  it('uses explicit destination and does not override it', async () => {
+    mockGetPreferredBuildConfig.mockResolvedValue({
+      scheme,
+      configuration: 'Release',
+      destination: 'platform=iOS Simulator,id=CACHED',
+    });
+
+    const xcodebuildBuildTool = await loadTool();
+
+    const result = await xcodebuildBuildTool({
+      projectPath,
+      scheme,
+      destination: 'generic/platform=macOS,name=Any Mac',
+      sdk: 'macosx',
+    });
+
+    const lastCall = mockBuildXcodebuildCommand.mock.calls.at(-1)![2] as any;
+    expect(lastCall.destination).toBe('generic/platform=macOS,name=Any Mac');
+    expect(mockGetPreferredSimulator).not.toHaveBeenCalled();
+
+    const response = responseFrom(result);
+    expect(response.intelligence.usedSmartDestination).toBe(false);
+  });
+
+  it('skips cached simulator destination when building for macOS', async () => {
+    mockGetPreferredBuildConfig.mockResolvedValue({
+      scheme,
+      configuration: 'Debug',
+      destination: 'platform=iOS Simulator,id=CACHED',
+    });
+
+    const xcodebuildBuildTool = await loadTool();
+
+    const result = await xcodebuildBuildTool({
+      projectPath,
+      scheme,
+      sdk: 'macosx',
+    });
+
+    const lastCall = mockBuildXcodebuildCommand.mock.calls.at(-1)![2] as any;
+    expect(lastCall.destination).toBeUndefined();
+
+    const response = responseFrom(result);
+    expect(response.intelligence.usedSmartDestination).toBe(false);
+  });
+
+  it('reuses cached destination when platform matches sdk', async () => {
+    mockGetPreferredBuildConfig.mockResolvedValue({
+      scheme,
+      configuration: 'Debug',
+      destination: 'platform=tvOS Simulator,id=TV-1',
+    });
+
+    const xcodebuildBuildTool = await loadTool();
+
+    const result = await xcodebuildBuildTool({
+      projectPath,
+      scheme,
+      sdk: 'tvossimulator',
+    });
+
+    const lastCall = mockBuildXcodebuildCommand.mock.calls.at(-1)![2] as any;
+    expect(lastCall.destination).toBe('platform=tvOS Simulator,id=TV-1');
+
+    const response = responseFrom(result);
+    expect(response.intelligence.usedSmartDestination).toBe(true);
+  });
+
+  it('selects a platform-matched simulator when no cached destination', async () => {
+    mockGetPreferredBuildConfig.mockResolvedValue({
+      scheme,
+      configuration: 'Debug',
+    });
+
+    mockGetPreferredSimulator.mockResolvedValue(null);
+    mockGetSimulatorList.mockResolvedValue({
+      devices: {
+        'com.apple.CoreSimulator.SimRuntime.tvOS-18-0': [
+          {
+            udid: 'TV-UDID',
+            name: 'Apple TV',
+            deviceTypeIdentifier: 'com.apple.CoreSimulator.SimDeviceType.Apple-TV-4K',
+            state: 'Shutdown',
+            isAvailable: true,
+            availability: 'available',
+            bootHistory: [],
+          },
+        ],
+        'com.apple.CoreSimulator.SimRuntime.iOS-18-0': [
+          {
+            udid: 'PHONE',
+            name: 'iPhone',
+            deviceTypeIdentifier: 'com.apple.CoreSimulator.SimDeviceType.iPhone-16',
+            state: 'Shutdown',
+            isAvailable: true,
+            availability: 'available',
+            bootHistory: [],
+          },
+        ],
+      },
+      runtimes: [],
+      devicetypes: [],
+      lastUpdated: new Date(),
+      preferredByProject: new Map(),
+    });
+
+    const xcodebuildBuildTool = await loadTool();
+
+    const result = await xcodebuildBuildTool({
+      projectPath,
+      scheme,
+      sdk: 'tvossimulator',
+    });
+
+    const lastCall = mockBuildXcodebuildCommand.mock.calls.at(-1)![2] as any;
+    expect(lastCall.destination).toBe('platform=tvOS Simulator,id=TV-UDID');
+
+    const response = responseFrom(result);
+    expect(response.intelligence.usedSmartDestination).toBe(true);
+  });
+
+  it('prioritizes caller-provided configuration over cached', async () => {
+    mockGetPreferredBuildConfig.mockResolvedValue({
+      scheme,
+      configuration: 'Debug',
+    });
+
+    const xcodebuildBuildTool = await loadTool();
+
+    await xcodebuildBuildTool({
+      projectPath,
+      scheme,
+      configuration: 'Release',
+    });
+
+    const lastCall = mockBuildXcodebuildCommand.mock.calls.at(-1)![2] as any;
+    expect(lastCall.configuration).toBe('Release');
+  });
+
+  it('uses cached configuration when caller does not provide one and marks smart usage', async () => {
+    mockGetPreferredBuildConfig.mockResolvedValue({
+      scheme,
+      configuration: 'Release',
+    });
+
+    const xcodebuildBuildTool = await loadTool();
+
+    const result = await xcodebuildBuildTool({
+      projectPath,
+      scheme,
+    });
+
+    const lastCall = mockBuildXcodebuildCommand.mock.calls.at(-1)![2] as any;
+    expect(lastCall.configuration).toBe('Release');
+
+    const response = responseFrom(result);
+    expect(response.intelligence.usedSmartConfiguration).toBe(true);
+  });
+});


### PR DESCRIPTION
This prevents not being able to run macOS builds at all because "iOS" was injected as destination regardless of destination parameter passed.
Fixes: prevent stale iOS simulator destinations from being applied, avoid hidden overrides when the caller provided a destination.

- fix argument handling so caller-supplied parameters are preserved and tracked, while cached values only fill genuine gaps; destination/sdk/config now resolve through an explicit/compatible path rather than being overwritten by prior runs (build.ts:73-118).
- Updated to correctly report when smart defaults were applied, based on whether the caller actually provided each parameter (build.ts:193-218).
- destination resolution: explicit destinations always win; cached destinations are only reused when platform-compatible; macOS and device SDKs avoid simulator carry-over; simulator suggestions are platform-filtered and derived from runtime tokens without hardcoded platform switches (build.ts:321-449).