### PR TITLE
Add compatibility with Swift Test

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(grep:*)",
+      "Bash(find:*)",
+      "Bash(npm run build:*)"
+    ]
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.2.0",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.17.1",
+        "@modelcontextprotocol/sdk": "^1.25.2",
         "@types/node": "^24.1.0"
       },
       "bin": {
@@ -75,6 +75,7 @@
       "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -783,6 +784,18 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.9",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
+      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1422,12 +1435,14 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.17.4",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.17.4.tgz",
-      "integrity": "sha512-zq24hfuAmmlNZvik0FLI58uE5sriN0WWsQzIlYnzSuKDAHFqJtBFrl/LfB1NLgJT5Y7dEBzaX4yAKqOPrcetaw==",
+      "version": "1.25.2",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.25.2.tgz",
+      "integrity": "sha512-LZFeo4F9M5qOhC/Uc1aQSrBHxMrvxett+9KLHt7OhcExtoiRN9DKgbZffMP/nxjutWDQpfMDfP3nkHI4X9ijww==",
       "license": "MIT",
       "dependencies": {
-        "ajv": "^6.12.6",
+        "@hono/node-server": "^1.19.7",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
         "cors": "^2.8.5",
         "cross-spawn": "^7.0.5",
@@ -1435,14 +1450,50 @@
         "eventsource-parser": "^3.0.0",
         "express": "^5.0.1",
         "express-rate-limit": "^7.5.0",
+        "jose": "^6.1.1",
+        "json-schema-typed": "^8.0.2",
         "pkce-challenge": "^5.0.0",
         "raw-body": "^3.0.0",
-        "zod": "^3.23.8",
-        "zod-to-json-schema": "^3.24.1"
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.0"
       },
       "engines": {
         "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
       }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
@@ -1685,6 +1736,7 @@
       "integrity": "sha512-jCzKdm/QK0Kg4V4IK/oMlRZlY+QOcdjv89U2NgKHZk1CYTj82/RVSx1mV/0gqCVMJ/DA+Zf/S4NBWNF8GQ+eqQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.48.0",
         "@typescript-eslint/types": "8.48.0",
@@ -2178,6 +2230,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2199,6 +2252,7 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -2210,6 +2264,45 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
@@ -2446,6 +2539,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -3093,6 +3187,7 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3153,6 +3248,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -3456,6 +3552,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
       "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.0",
@@ -3525,6 +3622,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
@@ -3533,6 +3631,22 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
@@ -3926,6 +4040,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hono": {
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.4.tgz",
+      "integrity": "sha512-U7tt8JsyrxSRKspfhtLET79pU8K+tInj5QZXs1jSugO1Vq5dFj3kmZsRldo29mTBfcjDRVRXrEZ6LS63Cog9ZA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -4261,6 +4385,7 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -4848,6 +4973,15 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/jose": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
+      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -4899,7 +5033,14 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -5780,6 +5921,7 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -5848,6 +5990,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5921,6 +6064,15 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6635,6 +6787,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6814,6 +6967,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6921,6 +7075,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
@@ -7258,21 +7413,22 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
+      "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zod-to-json-schema": {
-      "version": "3.24.6",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz",
-      "integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
       "license": "ISC",
       "peerDependencies": {
-        "zod": "^3.24.1"
+        "zod": "^3.25 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "package.json"
   ],
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.17.1",
+    "@modelcontextprotocol/sdk": "^1.25.2",
     "@types/node": "^24.1.0"
   },
   "devDependencies": {

--- a/src/registry/idb.ts
+++ b/src/registry/idb.ts
@@ -226,7 +226,7 @@ export function registerIdbTools(server: McpServer): void {
         appPath: z.string().optional(),
         streamOutput: z.boolean().optional(),
         arguments: z.array(z.string()).optional(),
-        environment: z.record(z.string()).optional(),
+        environment: z.record(z.string(), z.string()).optional(),
       },
       ...DEFER_LOADING_CONFIG,
     },

--- a/src/registry/simctl.ts
+++ b/src/registry/simctl.ts
@@ -173,7 +173,7 @@ export function registerSimctlTools(server: McpServer): void {
         bundleId: z.string().optional(),
         appPath: z.string().optional(),
         arguments: z.array(z.string()).optional(),
-        environment: z.record(z.string()).optional(),
+        environment: z.record(z.string(), z.string()).optional(),
       },
       ...DEFER_LOADING_CONFIG,
     },

--- a/src/registry/workflows.ts
+++ b/src/registry/workflows.ts
@@ -60,7 +60,7 @@ export function registerWorkflowTools(server: McpServer): void {
         eraseSimulator: z.boolean().default(false).describe('Wipe simulator data'),
         configuration: z.enum(['Debug', 'Release']).default('Debug'),
         launchArguments: z.array(z.string()).optional(),
-        environmentVariables: z.record(z.string()).optional(),
+        environmentVariables: z.record(z.string(), z.string()).optional(),
       },
       ...DEFER_LOADING_CONFIG,
     },

--- a/src/tools/xcodebuild/get-details.ts
+++ b/src/tools/xcodebuild/get-details.ts
@@ -118,14 +118,15 @@ export async function xcodebuildGetDetailsTool(args: any) {
 
       case 'errors-only': {
         const allOutput = cached.fullOutput + '\n' + cached.stderr;
-        const errorLines = allOutput
-          .split('\n')
-          .filter(
-            line =>
-              line.includes('error:') ||
-              line.includes('** BUILD FAILED **') ||
-              line.toLowerCase().includes('fatal error')
-          );
+        const errorLines = allOutput.split('\n').filter(
+          line =>
+            line.includes('error:') ||
+            line.includes('** BUILD FAILED **') ||
+            line.includes('** TEST FAILED **') ||
+            line.toLowerCase().includes('fatal error') ||
+            /Test case '[^']+' failed/i.test(line) || // Swift Testing failures
+            /Test Case '-\[.+\]' failed/.test(line) // XCTest failures
+        );
         responseText = JSON.stringify(
           {
             buildId,

--- a/src/tools/xcodebuild/xcodebuild-test.ts
+++ b/src/tools/xcodebuild/xcodebuild-test.ts
@@ -348,7 +348,7 @@ function parseTestResults(
 
   // Strategy 1: Count individual test results from per-test lines
   for (const line of lines) {
-    // Match: Test Case '-[ClassName testName]' passed/failed/skipped
+    // Match XCTest format: Test Case '-[ClassName testName]' passed/failed/skipped
     if (line.includes("Test Case '-[")) {
       if (line.includes(' passed ')) {
         results.passedTests++;
@@ -362,6 +362,26 @@ function parseTestResults(
       } else if (line.includes(' skipped ')) {
         results.skippedTests++;
       }
+      continue;
+    }
+
+    // Match Swift Testing format: Test case 'SuiteName/testName()' passed/failed on 'Device Name'
+    const swiftTestMatch = line.match(/Test case '([^']+)' (passed|failed) on '([^']+)'/i);
+    if (swiftTestMatch) {
+      const [, testName, status] = swiftTestMatch;
+      if (status.toLowerCase() === 'passed') {
+        results.passedTests++;
+      } else if (status.toLowerCase() === 'failed') {
+        results.failedTests++;
+        results.failedTestsList.push(testName);
+      }
+      continue;
+    }
+
+    // Match Swift Testing skipped tests
+    const swiftSkipMatch = line.match(/Test case '([^']+)' skipped/i);
+    if (swiftSkipMatch) {
+      results.skippedTests++;
     }
   }
 
@@ -390,11 +410,36 @@ function parseTestResults(
   // Fallback: calculate total from counted tests if summary line not found
   if (results.totalTests === 0) {
     results.totalTests = results.passedTests + results.failedTests + results.skippedTests;
-    if (results.totalTests === 0) {
+  }
+
+  // Strategy 3: Use ** TEST FAILED/SUCCEEDED ** markers as authoritative fallback
+  // These markers are always present in xcodebuild output regardless of test framework
+  const hasTestFailedMarker = output.includes('** TEST FAILED **');
+  const hasTestSucceededMarker = output.includes('** TEST SUCCEEDED **');
+
+  if (results.passedTests + results.failedTests + results.skippedTests === 0) {
+    // No individual test results parsed - use markers as fallback
+    if (hasTestFailedMarker) {
+      results.parseWarnings.push(
+        'No individual test results parsed but ** TEST FAILED ** marker present'
+      );
+      results.failedTests = 1; // Signal failure even though we could not parse individual tests
+      results.totalTests = 1;
+    } else if (hasTestSucceededMarker) {
+      results.parseWarnings.push(
+        'No individual test results parsed but ** TEST SUCCEEDED ** marker present'
+      );
+    } else {
       results.parseWarnings.push(
         'No test cases found in output - may indicate test compilation or setup failure'
       );
     }
+  } else if (results.failedTests === 0 && hasTestFailedMarker) {
+    // Mismatch: counted no failures but marker says failed
+    results.parseWarnings.push(
+      'Counted 0 failed tests but ** TEST FAILED ** marker present - adjusting failure count'
+    );
+    results.failedTests = Math.max(results.failedTests, 1);
   }
 
   return results;

--- a/tests/__tests__/tools/xcodebuild-test.test.ts
+++ b/tests/__tests__/tools/xcodebuild-test.test.ts
@@ -385,4 +385,165 @@ Test Case '-[MyAppTests testAnotherFailure]' failed (0.003 seconds)`,
       })
     );
   });
+
+  // Swift Testing Framework Tests
+  describe('Swift Testing framework parsing', () => {
+    it('should parse Swift Testing passed tests', async () => {
+      const args = {
+        projectPath: '/path/to/MyApp.xcodeproj',
+        scheme: 'MyApp',
+      };
+
+      mockValidateProjectPath.mockResolvedValue(undefined);
+      mockValidateScheme.mockReturnValue(undefined);
+      (projectCache.getPreferredBuildConfig as jest.MockedFunction<any>).mockResolvedValue(null);
+
+      jest.spyOn(Date, 'now').mockReturnValueOnce(1640995200000).mockReturnValueOnce(1640995210000);
+
+      // Swift Testing output format (Xcode 16+)
+      mockExecuteCommand.mockResolvedValue({
+        code: 0,
+        stdout: `Test run started.
+Test case 'MyTests/testExample()' passed on 'iPhone 16 Pro' (0.001 seconds)
+Test case 'MyTests/testAnother()' passed on 'iPhone 16 Pro' (0.002 seconds)
+Test case 'MyTests/testThird()' passed on 'iPhone 16 Pro' (0.003 seconds)
+** TEST SUCCEEDED **`,
+        stderr: '',
+      });
+
+      const result = await xcodebuildTestTool(args);
+
+      expect(result.isError).toBe(false);
+      const response = JSON.parse(result.content[0].text);
+      expect(response.success).toBe(true);
+      expect(response.summary.passed).toBe(3);
+      expect(response.summary.failed).toBe(0);
+      expect(response.summary.totalTests).toBe(3);
+    });
+
+    it('should parse Swift Testing failed tests', async () => {
+      const args = {
+        projectPath: '/path/to/MyApp.xcodeproj',
+        scheme: 'MyApp',
+      };
+
+      mockValidateProjectPath.mockResolvedValue(undefined);
+      mockValidateScheme.mockReturnValue(undefined);
+      (projectCache.getPreferredBuildConfig as jest.MockedFunction<any>).mockResolvedValue(null);
+
+      jest.spyOn(Date, 'now').mockReturnValueOnce(1640995200000).mockReturnValueOnce(1640995210000);
+
+      // Swift Testing output with failures
+      mockExecuteCommand.mockResolvedValue({
+        code: 1,
+        stdout: `Test run started.
+Test case 'MyTests/testExample()' passed on 'iPhone 16 Pro' (0.001 seconds)
+Test case 'MyTests/testFailure()' failed on 'iPhone 16 Pro' (0.002 seconds)
+Test case 'MyTests/testAnotherFailure()' failed on 'iPhone 16 Pro' (0.003 seconds)
+** TEST FAILED **`,
+        stderr: '',
+      });
+
+      const result = await xcodebuildTestTool(args);
+
+      expect(result.isError).toBe(true);
+      const response = JSON.parse(result.content[0].text);
+      expect(response.success).toBe(false);
+      expect(response.summary.passed).toBe(1);
+      expect(response.summary.failed).toBe(2);
+      expect(response.summary.totalTests).toBe(3);
+      expect(response.failureDetails.examples).toContain('MyTests/testFailure()');
+    });
+
+    it('should handle mixed XCTest and Swift Testing output', async () => {
+      const args = {
+        projectPath: '/path/to/MyApp.xcodeproj',
+        scheme: 'MyApp',
+      };
+
+      mockValidateProjectPath.mockResolvedValue(undefined);
+      mockValidateScheme.mockReturnValue(undefined);
+      (projectCache.getPreferredBuildConfig as jest.MockedFunction<any>).mockResolvedValue(null);
+
+      jest.spyOn(Date, 'now').mockReturnValueOnce(1640995200000).mockReturnValueOnce(1640995210000);
+
+      // Mixed output from both XCTest and Swift Testing
+      mockExecuteCommand.mockResolvedValue({
+        code: 0,
+        stdout: `Test run started.
+Test Case '-[MyXCTests testOldStyle]' passed (0.001 seconds)
+Test Case '-[MyXCTests testAnother]' passed (0.002 seconds)
+Test case 'MySwiftTests/testNewStyle()' passed on 'iPhone 16 Pro' (0.001 seconds)
+Test case 'MySwiftTests/testModern()' passed on 'iPhone 16 Pro' (0.002 seconds)
+** TEST SUCCEEDED **`,
+        stderr: '',
+      });
+
+      const result = await xcodebuildTestTool(args);
+
+      expect(result.isError).toBe(false);
+      const response = JSON.parse(result.content[0].text);
+      expect(response.success).toBe(true);
+      expect(response.summary.passed).toBe(4); // 2 XCTest + 2 Swift Testing
+      expect(response.summary.totalTests).toBe(4);
+    });
+
+    it('should use TEST FAILED marker when no individual tests parsed', async () => {
+      const args = {
+        projectPath: '/path/to/MyApp.xcodeproj',
+        scheme: 'MyApp',
+      };
+
+      mockValidateProjectPath.mockResolvedValue(undefined);
+      mockValidateScheme.mockReturnValue(undefined);
+      (projectCache.getPreferredBuildConfig as jest.MockedFunction<any>).mockResolvedValue(null);
+
+      jest.spyOn(Date, 'now').mockReturnValueOnce(1640995200000).mockReturnValueOnce(1640995210000);
+
+      // Output with no parseable test results but with failure marker
+      mockExecuteCommand.mockResolvedValue({
+        code: 1,
+        stdout: `Test run started.
+Some unparseable output format
+** TEST FAILED **`,
+        stderr: '',
+      });
+
+      const result = await xcodebuildTestTool(args);
+
+      expect(result.isError).toBe(true);
+      const response = JSON.parse(result.content[0].text);
+      expect(response.success).toBe(false);
+      expect(response.summary.failed).toBeGreaterThanOrEqual(1);
+    });
+
+    it('should use TEST SUCCEEDED marker when no individual tests parsed', async () => {
+      const args = {
+        projectPath: '/path/to/MyApp.xcodeproj',
+        scheme: 'MyApp',
+      };
+
+      mockValidateProjectPath.mockResolvedValue(undefined);
+      mockValidateScheme.mockReturnValue(undefined);
+      (projectCache.getPreferredBuildConfig as jest.MockedFunction<any>).mockResolvedValue(null);
+
+      jest.spyOn(Date, 'now').mockReturnValueOnce(1640995200000).mockReturnValueOnce(1640995210000);
+
+      // Output with no parseable test results but with success marker
+      mockExecuteCommand.mockResolvedValue({
+        code: 0,
+        stdout: `Test run started.
+Some unparseable output format
+** TEST SUCCEEDED **`,
+        stderr: '',
+      });
+
+      const result = await xcodebuildTestTool(args);
+
+      // Even without parsed tests, success marker means no error
+      expect(result.isError).toBe(false);
+      const response = JSON.parse(result.content[0].text);
+      expect(response.success).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
## What
- **Upgrade to Zod v4**
- **Add compatibility with Swift Test**

## Why
The MCP wasn't working with Claude Code 2.1.12, it would error out when it did tool discovery with the following error:
```
2026-01-19T18:02:08.360Z [ERROR] MCP server "xc-mcp" Failed to fetch tools: MCP error -32603: Cannot
  read properties of undefined (reading '_zod')
```

The xcodebuild-test tool would run my Swift tests but the summary would say 0 tests ran, so I added compatibility with the Swift test output style.