### PR TITLE
fix(registry): use z.record(z.string(), z.string()) to fix tools/list crash with MCP SDK >=1.28.0

### DIFF
--- a/src/registry/idb.ts
+++ b/src/registry/idb.ts
@@ -226,7 +226,7 @@ export function registerIdbTools(server: McpServer): void {
         appPath: z.string().optional(),
         streamOutput: z.boolean().optional(),
         arguments: z.array(z.string()).optional(),
-        environment: z.record(z.string()).optional(),
+        environment: z.record(z.string(), z.string()).optional(),
       },
       ...DEFER_LOADING_CONFIG,
     },

--- a/src/registry/simctl.ts
+++ b/src/registry/simctl.ts
@@ -173,7 +173,7 @@ export function registerSimctlTools(server: McpServer): void {
         bundleId: z.string().optional(),
         appPath: z.string().optional(),
         arguments: z.array(z.string()).optional(),
-        environment: z.record(z.string()).optional(),
+        environment: z.record(z.string(), z.string()).optional(),
       },
       ...DEFER_LOADING_CONFIG,
     },

--- a/src/registry/workflows.ts
+++ b/src/registry/workflows.ts
@@ -60,7 +60,7 @@ export function registerWorkflowTools(server: McpServer): void {
         eraseSimulator: z.boolean().default(false).describe('Wipe simulator data'),
         configuration: z.enum(['Debug', 'Release']).default('Debug'),
         launchArguments: z.array(z.string()).optional(),
-        environmentVariables: z.record(z.string()).optional(),
+        environmentVariables: z.record(z.string(), z.string()).optional(),
       },
       ...DEFER_LOADING_CONFIG,
     },


### PR DESCRIPTION
## Problem

`xc-mcp@3.2.0` initializes successfully in default mode and with `--mini`, but `tools/list` crashes with:

```
Cannot read properties of undefined (reading '_zod')
```

`--build-only` works fine and returns 10 tools. Default/mini modes fail because they additionally register `simctl-app`, `idb-app`, and `workflow-fresh-install`.

## Root Cause

In **Zod v4 Classic**, `z.record(valueSchema)` (1-argument form) stores the argument in `_zod.def.keyType` and leaves `_zod.def.valueType` as `undefined`:

```ts
const r = z.record(z.string());
r._zod.def.keyType   // ZodString ✓
r._zod.def.valueType // undefined ✗
```

`@modelcontextprotocol/sdk@1.28.0` introduced `zod-compat.js` which calls `z4mini.toJSONSchema()` on each registered tool's input schema during `tools/list`. When it recurses into the record schema and tries to convert `valueType`, it accesses `undefined._zod` → crash.

**Why only non-build-only mode?** The three tools registered outside `--build-only` are the only ones using `z.record(z.string())`:
- `simctl-app` → `environment`
- `idb-app` → `environment`  
- `workflow-fresh-install` → `environmentVariables`

## Fix

Use the explicit 2-argument form `z.record(z.string(), z.string())` which correctly populates both `keyType` and `valueType`:

```ts
// Before (broken with MCP SDK >=1.28.0)
environment: z.record(z.string()).optional()

// After
environment: z.record(z.string(), z.string()).optional()
```

## Verification

Tested with a minimal MCP stdio client — `tools/list` now returns all tools without error in default, `--mini`, and `--build-only` modes.

```
node -e "
import { z } from 'zod';
import * as z4mini from 'zod/v4-mini';
// 1-arg: FAILS
z4mini.toJSONSchema(z4mini.object({ env: z.record(z.string()) }));
// 2-arg: OK
z4mini.toJSONSchema(z4mini.object({ env: z.record(z.string(), z.string()) }));
"
```