### PR TITLE
v4 Phase 1: spec modernization (routers→discrete, annotations, listChanged, resources, structured output)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,9 @@
       "version": "3.2.0",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.17.1",
-        "@types/node": "^24.1.0"
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "@types/node": "^24.1.0",
+        "zod": "^4.4.3"
       },
       "bin": {
         "xc-mcp": "dist/index.js"
@@ -783,6 +784,18 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1422,27 +1435,66 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.17.4",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.17.4.tgz",
-      "integrity": "sha512-zq24hfuAmmlNZvik0FLI58uE5sriN0WWsQzIlYnzSuKDAHFqJtBFrl/LfB1NLgJT5Y7dEBzaX4yAKqOPrcetaw==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
       "dependencies": {
-        "ajv": "^6.12.6",
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
         "cors": "^2.8.5",
         "cross-spawn": "^7.0.5",
         "eventsource": "^3.0.2",
         "eventsource-parser": "^3.0.0",
-        "express": "^5.0.1",
-        "express-rate-limit": "^7.5.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
         "pkce-challenge": "^5.0.0",
         "raw-body": "^3.0.0",
-        "zod": "^3.23.8",
-        "zod-to-json-schema": "^3.24.1"
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
       },
       "engines": {
         "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
       }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
@@ -2199,6 +2251,7 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -2210,6 +2263,45 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
@@ -2384,23 +2476,27 @@
       "license": "MIT"
     },
     "node_modules/body-parser": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
-      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
         "content-type": "^1.0.5",
-        "debug": "^4.4.0",
+        "debug": "^4.4.3",
         "http-errors": "^2.0.0",
-        "iconv-lite": "^0.6.3",
+        "iconv-lite": "^0.7.0",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.0",
-        "raw-body": "^3.0.0",
-        "type-is": "^2.0.0"
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
       },
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/brace-expansion": {
@@ -2802,15 +2898,16 @@
       "license": "MIT"
     },
     "node_modules/content-disposition": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
-      "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "5.2.1"
-      },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/content-type": {
@@ -2875,9 +2972,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -3047,9 +3144,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -3452,18 +3549,19 @@
       }
     },
     "node_modules/express": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
-      "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
       "dependencies": {
         "accepts": "^2.0.0",
-        "body-parser": "^2.2.0",
+        "body-parser": "^2.2.1",
         "content-disposition": "^1.0.0",
         "content-type": "^1.0.5",
         "cookie": "^0.7.1",
         "cookie-signature": "^1.2.1",
         "debug": "^4.4.0",
+        "depd": "^2.0.0",
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
         "etag": "^1.8.1",
@@ -3494,10 +3592,13 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
-      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
       "engines": {
         "node": ">= 16"
       },
@@ -3525,6 +3626,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
@@ -3533,6 +3635,22 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
@@ -3571,9 +3689,9 @@
       }
     },
     "node_modules/finalhandler": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
-      "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -3584,7 +3702,11 @@
         "statuses": "^2.0.1"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/find-up": {
@@ -3915,15 +4037,24 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.25",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
       }
     },
     "node_modules/html-escaper": {
@@ -3934,28 +4065,23 @@
       "license": "MIT"
     },
     "node_modules/http-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "license": "MIT",
       "dependencies": {
-        "depd": "2.0.0",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "toidentifier": "1.0.1"
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/http-errors/node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/human-signals": {
@@ -3985,15 +4111,19 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ignore": {
@@ -4070,6 +4200,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -4848,6 +4987,15 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -4899,7 +5047,14 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -5250,15 +5405,19 @@
       }
     },
     "node_modules/mime-types": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
-      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
       "dependencies": {
         "mime-db": "^1.54.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/mimic-fn": {
@@ -5635,12 +5794,13 @@
       "license": "ISC"
     },
     "node_modules/path-to-regexp": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
-      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
-      "engines": {
-        "node": ">=16"
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/picocolors": {
@@ -5848,6 +6008,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5871,9 +6032,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -5895,18 +6056,18 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
-      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
       "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.6.3",
-        "unpipe": "1.0.0"
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 0.10"
       }
     },
     "node_modules/react-is": {
@@ -5921,6 +6082,15 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6028,26 +6198,6 @@
         "node": ">= 18"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -6068,31 +6218,35 @@
       }
     },
     "node_modules/send": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
-      "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
       "license": "MIT",
       "dependencies": {
-        "debug": "^4.3.5",
+        "debug": "^4.4.3",
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
         "etag": "^1.8.1",
         "fresh": "^2.0.0",
-        "http-errors": "^2.0.0",
-        "mime-types": "^3.0.1",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
         "ms": "^2.1.3",
         "on-finished": "^2.4.1",
         "range-parser": "^1.2.1",
-        "statuses": "^2.0.1"
+        "statuses": "^2.0.2"
       },
       "engines": {
         "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/serve-static": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
-      "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
       "license": "MIT",
       "dependencies": {
         "encodeurl": "^2.0.0",
@@ -6102,6 +6256,10 @@
       },
       "engines": {
         "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/setprototypeof": {
@@ -6132,14 +6290,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -6151,13 +6309,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6795,17 +6953,34 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typescript": {
@@ -6921,6 +7096,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
@@ -7258,21 +7434,21 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zod-to-json-schema": {
-      "version": "3.24.6",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz",
-      "integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
       "license": "ISC",
       "peerDependencies": {
-        "zod": "^3.24.1"
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -47,8 +47,9 @@
     "package.json"
   ],
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.17.1",
-    "@types/node": "^24.1.0"
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@types/node": "^24.1.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ class XcodeCLIMCPServer {
         capabilities: {
           tools: { listChanged: true },
           prompts: {},
+          resources: {},
         },
         instructions: `# XC-MCP: Accessibility-First Automation Workflow
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ class XcodeCLIMCPServer {
       },
       {
         capabilities: {
-          tools: {},
+          tools: { listChanged: true },
           prompts: {},
         },
         instructions: `# XC-MCP: Accessibility-First Automation Workflow

--- a/src/registry/cache.ts
+++ b/src/registry/cache.ts
@@ -3,12 +3,13 @@ import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import { validateXcodeInstallation } from '../utils/validation.js';
 import { getDescription } from './types.js';
-import { cacheTool, CACHE_DOCS, CACHE_DOCS_MINI } from '../tools/cache/index.js';
-import {
-  persistenceTool,
-  PERSISTENCE_DOCS,
-  PERSISTENCE_DOCS_MINI,
-} from '../tools/persistence/index.js';
+import { getCacheStatsTool, CACHE_GET_STATS_DOCS } from '../tools/cache/get-stats.js';
+import { getCacheConfigTool, CACHE_GET_CONFIG_DOCS } from '../tools/cache/get-config.js';
+import { setCacheConfigTool, CACHE_SET_CONFIG_DOCS } from '../tools/cache/set-config.js';
+import { clearCacheTool, CACHE_CLEAR_DOCS } from '../tools/cache/clear.js';
+import { persistenceEnableTool, PERSISTENCE_ENABLE_DOCS } from '../tools/persistence/enable.js';
+import { persistenceDisableTool, PERSISTENCE_DISABLE_DOCS } from '../tools/persistence/disable.js';
+import { persistenceStatusTool, PERSISTENCE_STATUS_DOCS } from '../tools/persistence/status.js';
 
 const ENABLE_DEFER_LOADING = process.env.XC_MCP_DEFER_LOADING !== 'false';
 const DEFER_LOADING_CONFIG = ENABLE_DEFER_LOADING
@@ -16,17 +17,18 @@ const DEFER_LOADING_CONFIG = ENABLE_DEFER_LOADING
   : {};
 
 export function registerCacheTools(server: McpServer): void {
-  // cache
+  // cache-get-stats
   server.registerTool(
-    'cache',
+    'cache-get-stats',
     {
-      description: getDescription(CACHE_DOCS, CACHE_DOCS_MINI),
-      inputSchema: {
-        operation: z.enum(['get-stats', 'get-config', 'set-config', 'clear']),
-        cacheType: z.enum(['simulator', 'project', 'response', 'all']).optional(),
-        maxAgeMs: z.number().optional(),
-        maxAgeMinutes: z.number().optional(),
-        maxAgeHours: z.number().optional(),
+      title: 'Get Cache Statistics',
+      description: getDescription(CACHE_GET_STATS_DOCS, CACHE_GET_STATS_DOCS),
+      inputSchema: {},
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
       },
       ...DEFER_LOADING_CONFIG,
     },
@@ -34,7 +36,7 @@ export function registerCacheTools(server: McpServer): void {
       try {
         await validateXcodeInstallation();
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        return (await cacheTool(args)) as any;
+        return (await getCacheStatsTool(args)) as any;
       } catch (error) {
         if (error instanceof McpError) throw error;
         throw new McpError(
@@ -45,16 +47,20 @@ export function registerCacheTools(server: McpServer): void {
     }
   );
 
-  // persistence
+  // cache-get-config
   server.registerTool(
-    'persistence',
+    'cache-get-config',
     {
-      description: getDescription(PERSISTENCE_DOCS, PERSISTENCE_DOCS_MINI),
+      title: 'Get Cache Configuration',
+      description: getDescription(CACHE_GET_CONFIG_DOCS, CACHE_GET_CONFIG_DOCS),
       inputSchema: {
-        operation: z.enum(['enable', 'disable', 'status']),
-        cacheDir: z.string().optional(),
-        clearData: z.boolean().default(false),
-        includeStorageInfo: z.boolean().default(true),
+        cacheType: z.enum(['simulator', 'project', 'response', 'all']).optional(),
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
       },
       ...DEFER_LOADING_CONFIG,
     },
@@ -62,7 +68,170 @@ export function registerCacheTools(server: McpServer): void {
       try {
         await validateXcodeInstallation();
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        return (await persistenceTool(args)) as any;
+        return (await getCacheConfigTool(args)) as any;
+      } catch (error) {
+        if (error instanceof McpError) throw error;
+        throw new McpError(
+          ErrorCode.InternalError,
+          `Tool execution failed: ${error instanceof Error ? error.message : String(error)}`
+        );
+      }
+    }
+  );
+
+  // cache-set-config
+  server.registerTool(
+    'cache-set-config',
+    {
+      title: 'Set Cache Configuration',
+      description: getDescription(CACHE_SET_CONFIG_DOCS, CACHE_SET_CONFIG_DOCS),
+      inputSchema: {
+        cacheType: z.enum(['simulator', 'project', 'response', 'all']),
+        maxAgeMs: z.number().optional(),
+        maxAgeMinutes: z.number().optional(),
+        maxAgeHours: z.number().optional(),
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+      ...DEFER_LOADING_CONFIG,
+    },
+    async args => {
+      try {
+        await validateXcodeInstallation();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return (await setCacheConfigTool(args)) as any;
+      } catch (error) {
+        if (error instanceof McpError) throw error;
+        throw new McpError(
+          ErrorCode.InternalError,
+          `Tool execution failed: ${error instanceof Error ? error.message : String(error)}`
+        );
+      }
+    }
+  );
+
+  // cache-clear
+  server.registerTool(
+    'cache-clear',
+    {
+      title: 'Clear Cache',
+      description: getDescription(CACHE_CLEAR_DOCS, CACHE_CLEAR_DOCS),
+      inputSchema: {
+        cacheType: z.enum(['simulator', 'project', 'response', 'all']).optional(),
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+      ...DEFER_LOADING_CONFIG,
+    },
+    async args => {
+      try {
+        await validateXcodeInstallation();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return (await clearCacheTool(args)) as any;
+      } catch (error) {
+        if (error instanceof McpError) throw error;
+        throw new McpError(
+          ErrorCode.InternalError,
+          `Tool execution failed: ${error instanceof Error ? error.message : String(error)}`
+        );
+      }
+    }
+  );
+
+  // persistence-enable
+  server.registerTool(
+    'persistence-enable',
+    {
+      title: 'Enable Disk Persistence',
+      description: getDescription(PERSISTENCE_ENABLE_DOCS, PERSISTENCE_ENABLE_DOCS),
+      inputSchema: {
+        cacheDir: z.string().optional(),
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+      ...DEFER_LOADING_CONFIG,
+    },
+    async args => {
+      try {
+        await validateXcodeInstallation();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return (await persistenceEnableTool(args)) as any;
+      } catch (error) {
+        if (error instanceof McpError) throw error;
+        throw new McpError(
+          ErrorCode.InternalError,
+          `Tool execution failed: ${error instanceof Error ? error.message : String(error)}`
+        );
+      }
+    }
+  );
+
+  // persistence-disable
+  server.registerTool(
+    'persistence-disable',
+    {
+      title: 'Disable Disk Persistence',
+      description: getDescription(PERSISTENCE_DISABLE_DOCS, PERSISTENCE_DISABLE_DOCS),
+      inputSchema: {
+        clearData: z.boolean().default(false),
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+      ...DEFER_LOADING_CONFIG,
+    },
+    async args => {
+      try {
+        await validateXcodeInstallation();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return (await persistenceDisableTool(args)) as any;
+      } catch (error) {
+        if (error instanceof McpError) throw error;
+        throw new McpError(
+          ErrorCode.InternalError,
+          `Tool execution failed: ${error instanceof Error ? error.message : String(error)}`
+        );
+      }
+    }
+  );
+
+  // persistence-status
+  server.registerTool(
+    'persistence-status',
+    {
+      title: 'Persistence Status',
+      description: getDescription(PERSISTENCE_STATUS_DOCS, PERSISTENCE_STATUS_DOCS),
+      inputSchema: {
+        includeStorageInfo: z.boolean().default(true),
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+      ...DEFER_LOADING_CONFIG,
+    },
+    async args => {
+      try {
+        await validateXcodeInstallation();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return (await persistenceStatusTool(args)) as any;
       } catch (error) {
         if (error instanceof McpError) throw error;
         throw new McpError(

--- a/src/registry/idb.ts
+++ b/src/registry/idb.ts
@@ -37,7 +37,10 @@ import {
   IDB_LIST_APPS_DOCS,
   IDB_LIST_APPS_DOCS_MINI,
 } from '../tools/idb/list-apps.js';
-import { idbAppTool, IDB_APP_DOCS, IDB_APP_DOCS_MINI } from '../tools/idb/app/index.js';
+import { idbInstallTool, IDB_INSTALL_DOCS } from '../tools/idb/install.js';
+import { idbUninstallTool, IDB_UNINSTALL_DOCS } from '../tools/idb/uninstall.js';
+import { idbLaunchTool, IDB_LAUNCH_DOCS } from '../tools/idb/launch.js';
+import { idbTerminateTool, IDB_TERMINATE_DOCS } from '../tools/idb/terminate.js';
 
 const ENABLE_DEFER_LOADING = process.env.XC_MCP_DEFER_LOADING !== 'false';
 const DEFER_LOADING_CONFIG = ENABLE_DEFER_LOADING
@@ -49,12 +52,19 @@ export function registerIdbTools(server: McpServer): void {
   server.registerTool(
     'idb-targets',
     {
+      title: 'Manage IDB Targets',
       description: getDescription(IDB_TARGETS_DOCS, IDB_TARGETS_DOCS_MINI),
       inputSchema: {
         operation: z.enum(['list', 'describe', 'focus', 'connect', 'disconnect']),
         udid: z.string().optional(),
         state: z.enum(['Booted', 'Shutdown']).optional(),
         type: z.enum(['device', 'simulator']).optional(),
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
       },
       ...DEFER_LOADING_CONFIG,
     },
@@ -65,6 +75,7 @@ export function registerIdbTools(server: McpServer): void {
   server.registerTool(
     'idb-ui-tap',
     {
+      title: 'Tap UI Element',
       description: getDescription(IDB_UI_TAP_DOCS, IDB_UI_TAP_DOCS_MINI),
       inputSchema: {
         udid: z.string().optional(),
@@ -81,6 +92,12 @@ export function registerIdbTools(server: McpServer): void {
         testScenario: z.string().optional(),
         step: z.number().optional(),
       },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: false,
+      },
       ...DEFER_LOADING_CONFIG,
     },
     async args => idbUiTapTool(args)
@@ -90,6 +107,7 @@ export function registerIdbTools(server: McpServer): void {
   server.registerTool(
     'idb-ui-input',
     {
+      title: 'Send Text/Key Input',
       description: getDescription(IDB_UI_INPUT_DOCS, IDB_UI_INPUT_DOCS_MINI),
       inputSchema: {
         udid: z.string().optional(),
@@ -117,6 +135,12 @@ export function registerIdbTools(server: McpServer): void {
         expectedOutcome: z.string().optional(),
         isSensitive: z.boolean().optional(),
       },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: false,
+      },
       ...DEFER_LOADING_CONFIG,
     },
     async args => idbUiInputTool(args)
@@ -126,6 +150,7 @@ export function registerIdbTools(server: McpServer): void {
   server.registerTool(
     'idb-ui-gesture',
     {
+      title: 'Perform Gesture / Button Press',
       description: getDescription(IDB_UI_GESTURE_DOCS, IDB_UI_GESTURE_DOCS_MINI),
       inputSchema: {
         udid: z.string().optional(),
@@ -145,6 +170,12 @@ export function registerIdbTools(server: McpServer): void {
         actionName: z.string().optional(),
         expectedOutcome: z.string().optional(),
       },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: false,
+      },
       ...DEFER_LOADING_CONFIG,
     },
     async args => idbUiGestureTool(args)
@@ -154,6 +185,7 @@ export function registerIdbTools(server: McpServer): void {
   server.registerTool(
     'idb-ui-describe',
     {
+      title: 'Describe Accessibility Tree',
       description: getDescription(IDB_UI_DESCRIBE_DOCS, IDB_UI_DESCRIBE_DOCS_MINI),
       inputSchema: {
         udid: z.string().optional(),
@@ -162,6 +194,12 @@ export function registerIdbTools(server: McpServer): void {
         y: z.number().optional(),
         screenContext: z.string().optional(),
         purposeDescription: z.string().optional(),
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
       },
       ...DEFER_LOADING_CONFIG,
     },
@@ -172,10 +210,17 @@ export function registerIdbTools(server: McpServer): void {
   server.registerTool(
     'idb-ui-find-element',
     {
+      title: 'Find UI Element',
       description: getDescription(IDB_UI_FIND_ELEMENT_DOCS, IDB_UI_FIND_ELEMENT_DOCS_MINI),
       inputSchema: {
         udid: z.string().optional(),
         query: z.string(),
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
       },
       ...DEFER_LOADING_CONFIG,
     },
@@ -186,6 +231,7 @@ export function registerIdbTools(server: McpServer): void {
   server.registerTool(
     'accessibility-quality-check',
     {
+      title: 'Accessibility Quality Check',
       description: getDescription(
         ACCESSIBILITY_QUALITY_CHECK_DOCS,
         ACCESSIBILITY_QUALITY_CHECK_DOCS_MINI
@@ -193,6 +239,12 @@ export function registerIdbTools(server: McpServer): void {
       inputSchema: {
         udid: z.string().optional(),
         screenContext: z.string().optional(),
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
       },
       ...DEFER_LOADING_CONFIG,
     },
@@ -203,33 +255,108 @@ export function registerIdbTools(server: McpServer): void {
   server.registerTool(
     'idb-list-apps',
     {
+      title: 'List Installed Apps (IDB)',
       description: getDescription(IDB_LIST_APPS_DOCS, IDB_LIST_APPS_DOCS_MINI),
       inputSchema: {
         udid: z.string().optional(),
         filterType: z.enum(['system', 'user', 'internal']).optional(),
         runningOnly: z.boolean().optional(),
       },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
       ...DEFER_LOADING_CONFIG,
     },
     async args => idbListAppsTool(args)
   );
 
-  // idb-app
+  // idb-install
   server.registerTool(
-    'idb-app',
+    'idb-install',
     {
-      description: getDescription(IDB_APP_DOCS, IDB_APP_DOCS_MINI),
+      title: 'Install App (IDB)',
+      description: getDescription(IDB_INSTALL_DOCS, IDB_INSTALL_DOCS),
       inputSchema: {
-        operation: z.enum(['install', 'uninstall', 'launch', 'terminate']),
         udid: z.string().optional(),
-        bundleId: z.string().optional(),
-        appPath: z.string().optional(),
+        appPath: z.string(),
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+      ...DEFER_LOADING_CONFIG,
+    },
+    async args => idbInstallTool(args)
+  );
+
+  // idb-uninstall
+  server.registerTool(
+    'idb-uninstall',
+    {
+      title: 'Uninstall App (IDB)',
+      description: getDescription(IDB_UNINSTALL_DOCS, IDB_UNINSTALL_DOCS),
+      inputSchema: {
+        udid: z.string().optional(),
+        bundleId: z.string(),
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+      ...DEFER_LOADING_CONFIG,
+    },
+    async args => idbUninstallTool(args)
+  );
+
+  // idb-launch
+  server.registerTool(
+    'idb-launch',
+    {
+      title: 'Launch App (IDB)',
+      description: getDescription(IDB_LAUNCH_DOCS, IDB_LAUNCH_DOCS),
+      inputSchema: {
+        udid: z.string().optional(),
+        bundleId: z.string(),
         streamOutput: z.boolean().optional(),
         arguments: z.array(z.string()).optional(),
         environment: z.record(z.string(), z.string()).optional(),
       },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: false,
+      },
       ...DEFER_LOADING_CONFIG,
     },
-    async args => idbAppTool(args)
+    async args => idbLaunchTool(args)
+  );
+
+  // idb-terminate
+  server.registerTool(
+    'idb-terminate',
+    {
+      title: 'Terminate App (IDB)',
+      description: getDescription(IDB_TERMINATE_DOCS, IDB_TERMINATE_DOCS),
+      inputSchema: {
+        udid: z.string().optional(),
+        bundleId: z.string(),
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+      ...DEFER_LOADING_CONFIG,
+    },
+    async args => idbTerminateTool(args)
   );
 }

--- a/src/registry/idb.ts
+++ b/src/registry/idb.ts
@@ -226,7 +226,7 @@ export function registerIdbTools(server: McpServer): void {
         appPath: z.string().optional(),
         streamOutput: z.boolean().optional(),
         arguments: z.array(z.string()).optional(),
-        environment: z.record(z.string()).optional(),
+        environment: z.record(z.string(), z.string()).optional(),
       },
       ...DEFER_LOADING_CONFIG,
     },

--- a/src/registry/idb.ts
+++ b/src/registry/idb.ts
@@ -240,6 +240,14 @@ export function registerIdbTools(server: McpServer): void {
         udid: z.string().optional(),
         screenContext: z.string().optional(),
       },
+      outputSchema: {
+        success: z.boolean(),
+        quality: z.string().describe('rich | moderate | minimal'),
+        recommendation: z.string().describe('accessibility-ready | consider-screenshot'),
+        totalElements: z.number(),
+        tappableElements: z.number(),
+        textFields: z.number(),
+      },
       annotations: {
         readOnlyHint: true,
         destructiveHint: false,

--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -6,6 +6,7 @@ import { registerIdbTools } from './idb.js';
 import { registerCacheTools } from './cache.js';
 import { registerWorkflowTools } from './workflows.js';
 import { registerSystemTools } from './system.js';
+import { registerResources } from './resources.js';
 
 /**
  * Register all XC-MCP tools with the MCP server
@@ -23,6 +24,9 @@ export function registerAllTools(server: McpServer): void {
   registerSimctlListTool(server);
   registerCacheTools(server);
   registerSystemTools(server);
+
+  // Progressive-disclosure cached output, exposed as MCP resources
+  registerResources(server);
 
   // Only register full toolset when NOT in build-only mode
   if (!config.buildOnly) {

--- a/src/registry/resources.ts
+++ b/src/registry/resources.ts
@@ -1,0 +1,67 @@
+import { McpServer, ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js';
+import {
+  responseCache,
+  responseResourceUri,
+  RESPONSE_RESOURCE_PREFIX,
+} from '../utils/response-cache.js';
+
+/**
+ * Register MCP resources for progressive-disclosure cached output.
+ *
+ * Tools that produce large output (xcodebuild-build/-test, simctl-list, idb-ui-describe)
+ * cache it under an opaque id and return a `resource_link` to `xcmcp://response/{cacheId}`.
+ * Spec-aware clients can read that resource directly instead of calling a *-get-details tool.
+ * The cache id is still returned in the tool payload for older clients (backwards compatible).
+ */
+export function registerResources(server: McpServer): void {
+  server.registerResource(
+    'cached-response',
+    new ResourceTemplate(`${RESPONSE_RESOURCE_PREFIX}{cacheId}`, {
+      list: () => ({
+        resources: responseCache.list().map(cached => ({
+          uri: responseResourceUri(cached.id),
+          name: `${cached.tool}-output`,
+          description: `Cached ${cached.tool} output from ${cached.timestamp.toISOString()} (exit ${cached.exitCode})`,
+          mimeType: 'text/plain',
+        })),
+      }),
+    }),
+    {
+      title: 'Cached Tool Output',
+      description:
+        'Full output of a prior tool run (build logs, simulator lists, accessibility trees), addressable by its cache id.',
+      mimeType: 'text/plain',
+    },
+    async (uri, variables) => {
+      const cacheId = Array.isArray(variables.cacheId) ? variables.cacheId[0] : variables.cacheId;
+      const cached = cacheId ? responseCache.get(cacheId) : undefined;
+
+      if (!cached) {
+        return {
+          contents: [
+            {
+              uri: uri.href,
+              mimeType: 'text/plain',
+              text: `No cached response found for id "${cacheId}". It may have expired (30 min TTL) or never existed.`,
+            },
+          ],
+        };
+      }
+
+      const sections = [cached.fullOutput];
+      if (cached.stderr?.trim()) {
+        sections.push(`\n--- stderr ---\n${cached.stderr}`);
+      }
+
+      return {
+        contents: [
+          {
+            uri: uri.href,
+            mimeType: 'text/plain',
+            text: sections.join('\n'),
+          },
+        ],
+      };
+    }
+  );
+}

--- a/src/registry/simctl.ts
+++ b/src/registry/simctl.ts
@@ -173,7 +173,7 @@ export function registerSimctlTools(server: McpServer): void {
         bundleId: z.string().optional(),
         appPath: z.string().optional(),
         arguments: z.array(z.string()).optional(),
-        environment: z.record(z.string()).optional(),
+        environment: z.record(z.string(), z.string()).optional(),
       },
       ...DEFER_LOADING_CONFIG,
     },

--- a/src/registry/simctl.ts
+++ b/src/registry/simctl.ts
@@ -37,6 +37,12 @@ import {
   SIMCTL_SCREENSHOT_INLINE_DOCS,
   SIMCTL_SCREENSHOT_INLINE_DOCS_MINI,
 } from '../tools/simctl/screenshot-inline.js';
+import { simctlAddmediaTool, SIMCTL_ADDMEDIA_DOCS } from '../tools/simctl/addmedia.js';
+import { simctlPbcopyTool, SIMCTL_PBCOPY_DOCS } from '../tools/simctl/pbcopy.js';
+import { simctlPrivacyTool, SIMCTL_PRIVACY_DOCS } from '../tools/simctl/privacy.js';
+import { simctlStatusBarTool, SIMCTL_STATUS_BAR_DOCS } from '../tools/simctl/status-bar.js';
+import { streamLogsTool, SIMCTL_STREAM_LOGS_DOCS } from '../tools/simctl/stream-logs.js';
+import { simctlSuggestTool, SIMCTL_SUGGEST_DOCS } from '../tools/simctl/suggest.js';
 
 const ENABLE_DEFER_LOADING = process.env.XC_MCP_DEFER_LOADING !== 'false';
 const DEFER_LOADING_CONFIG = ENABLE_DEFER_LOADING
@@ -326,6 +332,170 @@ export function registerSimctlTools(server: McpServer): void {
       try {
         await validateXcodeInstallation();
         return await simctlScreenshotInlineTool(args);
+      } catch (error) {
+        if (error instanceof McpError) throw error;
+        throw new McpError(
+          ErrorCode.InternalError,
+          `Tool execution failed: ${error instanceof Error ? error.message : String(error)}`
+        );
+      }
+    }
+  );
+
+  // simctl-addmedia
+  server.registerTool(
+    'simctl-addmedia',
+    {
+      description: getDescription(SIMCTL_ADDMEDIA_DOCS, SIMCTL_ADDMEDIA_DOCS),
+      inputSchema: {
+        udid: z.string(),
+        mediaPath: z.string(),
+      },
+      ...DEFER_LOADING_CONFIG,
+    },
+    async args => {
+      try {
+        await validateXcodeInstallation();
+        return await simctlAddmediaTool(args);
+      } catch (error) {
+        if (error instanceof McpError) throw error;
+        throw new McpError(
+          ErrorCode.InternalError,
+          `Tool execution failed: ${error instanceof Error ? error.message : String(error)}`
+        );
+      }
+    }
+  );
+
+  // simctl-pbcopy
+  server.registerTool(
+    'simctl-pbcopy',
+    {
+      description: getDescription(SIMCTL_PBCOPY_DOCS, SIMCTL_PBCOPY_DOCS),
+      inputSchema: {
+        udid: z.string(),
+        text: z.string(),
+      },
+      ...DEFER_LOADING_CONFIG,
+    },
+    async args => {
+      try {
+        await validateXcodeInstallation();
+        return await simctlPbcopyTool(args);
+      } catch (error) {
+        if (error instanceof McpError) throw error;
+        throw new McpError(
+          ErrorCode.InternalError,
+          `Tool execution failed: ${error instanceof Error ? error.message : String(error)}`
+        );
+      }
+    }
+  );
+
+  // simctl-privacy
+  server.registerTool(
+    'simctl-privacy',
+    {
+      description: getDescription(SIMCTL_PRIVACY_DOCS, SIMCTL_PRIVACY_DOCS),
+      inputSchema: {
+        udid: z.string(),
+        bundleId: z.string(),
+        action: z.enum(['grant', 'revoke', 'reset']),
+        service: z.string(),
+        scenario: z.string().optional(),
+        step: z.number().optional(),
+      },
+      ...DEFER_LOADING_CONFIG,
+    },
+    async args => {
+      try {
+        await validateXcodeInstallation();
+        return await simctlPrivacyTool(args);
+      } catch (error) {
+        if (error instanceof McpError) throw error;
+        throw new McpError(
+          ErrorCode.InternalError,
+          `Tool execution failed: ${error instanceof Error ? error.message : String(error)}`
+        );
+      }
+    }
+  );
+
+  // simctl-status-bar
+  server.registerTool(
+    'simctl-status-bar',
+    {
+      description: getDescription(SIMCTL_STATUS_BAR_DOCS, SIMCTL_STATUS_BAR_DOCS),
+      inputSchema: {
+        udid: z.string(),
+        operation: z.enum(['override', 'clear']),
+        time: z.string().optional(),
+        dataNetwork: z.string().optional(),
+        wifiMode: z.string().optional(),
+        batteryState: z.string().optional(),
+        batteryLevel: z.number().optional(),
+      },
+      ...DEFER_LOADING_CONFIG,
+    },
+    async args => {
+      try {
+        await validateXcodeInstallation();
+        return await simctlStatusBarTool(args);
+      } catch (error) {
+        if (error instanceof McpError) throw error;
+        throw new McpError(
+          ErrorCode.InternalError,
+          `Tool execution failed: ${error instanceof Error ? error.message : String(error)}`
+        );
+      }
+    }
+  );
+
+  // simctl-stream-logs
+  server.registerTool(
+    'simctl-stream-logs',
+    {
+      description: getDescription(SIMCTL_STREAM_LOGS_DOCS, SIMCTL_STREAM_LOGS_DOCS),
+      inputSchema: {
+        udid: z.string(),
+        bundleId: z.string().optional(),
+        predicate: z.string().optional(),
+        duration: z.number().optional(),
+        capture: z.boolean().optional(),
+      },
+      ...DEFER_LOADING_CONFIG,
+    },
+    async args => {
+      try {
+        await validateXcodeInstallation();
+        return await streamLogsTool(args);
+      } catch (error) {
+        if (error instanceof McpError) throw error;
+        throw new McpError(
+          ErrorCode.InternalError,
+          `Tool execution failed: ${error instanceof Error ? error.message : String(error)}`
+        );
+      }
+    }
+  );
+
+  // simctl-suggest
+  server.registerTool(
+    'simctl-suggest',
+    {
+      description: getDescription(SIMCTL_SUGGEST_DOCS, SIMCTL_SUGGEST_DOCS),
+      inputSchema: {
+        projectPath: z.string().optional(),
+        deviceType: z.string().optional(),
+        maxSuggestions: z.number().optional(),
+        autoBootTopSuggestion: z.boolean().optional(),
+      },
+      ...DEFER_LOADING_CONFIG,
+    },
+    async args => {
+      try {
+        await validateXcodeInstallation();
+        return await simctlSuggestTool(args);
       } catch (error) {
         if (error instanceof McpError) throw error;
         throw new McpError(

--- a/src/registry/simctl.ts
+++ b/src/registry/simctl.ts
@@ -10,16 +10,21 @@ import {
   SIMCTL_GET_DETAILS_DOCS_MINI,
 } from '../tools/simctl/get-details.js';
 import {
-  simctlDeviceTool,
-  SIMCTL_DEVICE_DOCS,
-  SIMCTL_DEVICE_DOCS_MINI,
-} from '../tools/simctl/device/index.js';
-import {
   simctlHealthCheckTool,
   SIMCTL_HEALTH_CHECK_DOCS,
   SIMCTL_HEALTH_CHECK_DOCS_MINI,
 } from '../tools/simctl/health-check.js';
-import { simctlAppTool, SIMCTL_APP_DOCS, SIMCTL_APP_DOCS_MINI } from '../tools/simctl/app/index.js';
+import { simctlBootTool, SIMCTL_BOOT_DOCS } from '../tools/simctl/boot.js';
+import { simctlShutdownTool, SIMCTL_SHUTDOWN_DOCS } from '../tools/simctl/shutdown.js';
+import { simctlCreateTool, SIMCTL_CREATE_DOCS } from '../tools/simctl/create.js';
+import { simctlDeleteTool, SIMCTL_DELETE_DOCS } from '../tools/simctl/delete.js';
+import { simctlEraseTool, SIMCTL_ERASE_DOCS } from '../tools/simctl/erase.js';
+import { simctlCloneTool, SIMCTL_CLONE_DOCS } from '../tools/simctl/clone.js';
+import { simctlRenameTool, SIMCTL_RENAME_DOCS } from '../tools/simctl/rename.js';
+import { simctlInstallTool, SIMCTL_INSTALL_DOCS } from '../tools/simctl/install.js';
+import { simctlUninstallTool, SIMCTL_UNINSTALL_DOCS } from '../tools/simctl/uninstall.js';
+import { simctlLaunchTool, SIMCTL_LAUNCH_DOCS } from '../tools/simctl/launch.js';
+import { simctlTerminateTool, SIMCTL_TERMINATE_DOCS } from '../tools/simctl/terminate.js';
 import {
   simctlGetAppContainerTool,
   SIMCTL_GET_APP_CONTAINER_DOCS,
@@ -56,6 +61,7 @@ export function registerSimctlListTool(server: McpServer): void {
   server.registerTool(
     'simctl-list',
     {
+      title: 'List Simulators',
       description: getDescription(SIMCTL_LIST_DOCS, SIMCTL_LIST_DOCS_MINI),
       inputSchema: {
         deviceType: z.string().optional(),
@@ -64,6 +70,12 @@ export function registerSimctlListTool(server: McpServer): void {
         outputFormat: z.enum(['json', 'text']).default('json'),
         concise: z.boolean().default(true),
         max: z.number().default(5),
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
       },
       ...DEFER_LOADING_CONFIG,
     },
@@ -90,6 +102,7 @@ export function registerSimctlTools(server: McpServer): void {
   server.registerTool(
     'simctl-get-details',
     {
+      title: 'Get Simulator List Details',
       description: getDescription(SIMCTL_GET_DETAILS_DOCS, SIMCTL_GET_DETAILS_DOCS_MINI),
       inputSchema: {
         cacheId: z.string(),
@@ -97,6 +110,12 @@ export function registerSimctlTools(server: McpServer): void {
         deviceType: z.string().optional(),
         runtime: z.string().optional(),
         maxDevices: z.number().default(20),
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
       },
       ...DEFER_LOADING_CONFIG,
     },
@@ -114,28 +133,220 @@ export function registerSimctlTools(server: McpServer): void {
     }
   );
 
-  // simctl-device
+  // simctl-boot
   server.registerTool(
-    'simctl-device',
+    'simctl-boot',
     {
-      description: getDescription(SIMCTL_DEVICE_DOCS, SIMCTL_DEVICE_DOCS_MINI),
+      title: 'Boot Simulator',
+      description: getDescription(SIMCTL_BOOT_DOCS, SIMCTL_BOOT_DOCS),
       inputSchema: {
-        operation: z.enum(['boot', 'shutdown', 'create', 'delete', 'erase', 'clone', 'rename']),
-        deviceId: z.string().optional(),
+        deviceId: z.string(),
         waitForBoot: z.boolean().default(true),
         openGui: z.boolean().default(true),
-        name: z.string().optional(),
-        deviceType: z.string().optional(),
-        runtime: z.string().optional(),
-        force: z.boolean().default(false),
-        newName: z.string().optional(),
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
       },
       ...DEFER_LOADING_CONFIG,
     },
     async args => {
       try {
         await validateXcodeInstallation();
-        return await simctlDeviceTool(args);
+        return await simctlBootTool(args);
+      } catch (error) {
+        if (error instanceof McpError) throw error;
+        throw new McpError(
+          ErrorCode.InternalError,
+          `Tool execution failed: ${error instanceof Error ? error.message : String(error)}`
+        );
+      }
+    }
+  );
+
+  // simctl-shutdown
+  server.registerTool(
+    'simctl-shutdown',
+    {
+      title: 'Shutdown Simulator',
+      description: getDescription(SIMCTL_SHUTDOWN_DOCS, SIMCTL_SHUTDOWN_DOCS),
+      inputSchema: {
+        deviceId: z.string(),
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+      ...DEFER_LOADING_CONFIG,
+    },
+    async args => {
+      try {
+        await validateXcodeInstallation();
+        return await simctlShutdownTool(args);
+      } catch (error) {
+        if (error instanceof McpError) throw error;
+        throw new McpError(
+          ErrorCode.InternalError,
+          `Tool execution failed: ${error instanceof Error ? error.message : String(error)}`
+        );
+      }
+    }
+  );
+
+  // simctl-create
+  server.registerTool(
+    'simctl-create',
+    {
+      title: 'Create Simulator',
+      description: getDescription(SIMCTL_CREATE_DOCS, SIMCTL_CREATE_DOCS),
+      inputSchema: {
+        name: z.string(),
+        deviceType: z.string(),
+        runtime: z.string().optional(),
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: false,
+      },
+      ...DEFER_LOADING_CONFIG,
+    },
+    async args => {
+      try {
+        await validateXcodeInstallation();
+        return await simctlCreateTool(args);
+      } catch (error) {
+        if (error instanceof McpError) throw error;
+        throw new McpError(
+          ErrorCode.InternalError,
+          `Tool execution failed: ${error instanceof Error ? error.message : String(error)}`
+        );
+      }
+    }
+  );
+
+  // simctl-delete
+  server.registerTool(
+    'simctl-delete',
+    {
+      title: 'Delete Simulator',
+      description: getDescription(SIMCTL_DELETE_DOCS, SIMCTL_DELETE_DOCS),
+      inputSchema: {
+        deviceId: z.string(),
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+      ...DEFER_LOADING_CONFIG,
+    },
+    async args => {
+      try {
+        await validateXcodeInstallation();
+        return await simctlDeleteTool(args);
+      } catch (error) {
+        if (error instanceof McpError) throw error;
+        throw new McpError(
+          ErrorCode.InternalError,
+          `Tool execution failed: ${error instanceof Error ? error.message : String(error)}`
+        );
+      }
+    }
+  );
+
+  // simctl-erase
+  server.registerTool(
+    'simctl-erase',
+    {
+      title: 'Erase Simulator (Factory Reset)',
+      description: getDescription(SIMCTL_ERASE_DOCS, SIMCTL_ERASE_DOCS),
+      inputSchema: {
+        deviceId: z.string(),
+        force: z.boolean().default(false),
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+      ...DEFER_LOADING_CONFIG,
+    },
+    async args => {
+      try {
+        await validateXcodeInstallation();
+        return await simctlEraseTool(args);
+      } catch (error) {
+        if (error instanceof McpError) throw error;
+        throw new McpError(
+          ErrorCode.InternalError,
+          `Tool execution failed: ${error instanceof Error ? error.message : String(error)}`
+        );
+      }
+    }
+  );
+
+  // simctl-clone
+  server.registerTool(
+    'simctl-clone',
+    {
+      title: 'Clone Simulator',
+      description: getDescription(SIMCTL_CLONE_DOCS, SIMCTL_CLONE_DOCS),
+      inputSchema: {
+        deviceId: z.string(),
+        newName: z.string(),
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: false,
+      },
+      ...DEFER_LOADING_CONFIG,
+    },
+    async args => {
+      try {
+        await validateXcodeInstallation();
+        return await simctlCloneTool(args);
+      } catch (error) {
+        if (error instanceof McpError) throw error;
+        throw new McpError(
+          ErrorCode.InternalError,
+          `Tool execution failed: ${error instanceof Error ? error.message : String(error)}`
+        );
+      }
+    }
+  );
+
+  // simctl-rename
+  server.registerTool(
+    'simctl-rename',
+    {
+      title: 'Rename Simulator',
+      description: getDescription(SIMCTL_RENAME_DOCS, SIMCTL_RENAME_DOCS),
+      inputSchema: {
+        deviceId: z.string(),
+        newName: z.string(),
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+      ...DEFER_LOADING_CONFIG,
+    },
+    async args => {
+      try {
+        await validateXcodeInstallation();
+        return await simctlRenameTool(args);
       } catch (error) {
         if (error instanceof McpError) throw error;
         throw new McpError(
@@ -150,8 +361,15 @@ export function registerSimctlTools(server: McpServer): void {
   server.registerTool(
     'simctl-health-check',
     {
+      title: 'Simulator Environment Health Check',
       description: getDescription(SIMCTL_HEALTH_CHECK_DOCS, SIMCTL_HEALTH_CHECK_DOCS_MINI),
       inputSchema: {},
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
       ...DEFER_LOADING_CONFIG,
     },
     async _args => {
@@ -168,25 +386,126 @@ export function registerSimctlTools(server: McpServer): void {
     }
   );
 
-  // simctl-app
+  // simctl-install
   server.registerTool(
-    'simctl-app',
+    'simctl-install',
     {
-      description: getDescription(SIMCTL_APP_DOCS, SIMCTL_APP_DOCS_MINI),
+      title: 'Install App on Simulator',
+      description: getDescription(SIMCTL_INSTALL_DOCS, SIMCTL_INSTALL_DOCS),
       inputSchema: {
-        operation: z.enum(['install', 'uninstall', 'launch', 'terminate']),
-        udid: z.string().optional(),
-        bundleId: z.string().optional(),
-        appPath: z.string().optional(),
-        arguments: z.array(z.string()).optional(),
-        environment: z.record(z.string(), z.string()).optional(),
+        udid: z.string(),
+        appPath: z.string(),
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
       },
       ...DEFER_LOADING_CONFIG,
     },
     async args => {
       try {
         await validateXcodeInstallation();
-        return await simctlAppTool(args);
+        return await simctlInstallTool(args);
+      } catch (error) {
+        if (error instanceof McpError) throw error;
+        throw new McpError(
+          ErrorCode.InternalError,
+          `Tool execution failed: ${error instanceof Error ? error.message : String(error)}`
+        );
+      }
+    }
+  );
+
+  // simctl-uninstall
+  server.registerTool(
+    'simctl-uninstall',
+    {
+      title: 'Uninstall App from Simulator',
+      description: getDescription(SIMCTL_UNINSTALL_DOCS, SIMCTL_UNINSTALL_DOCS),
+      inputSchema: {
+        udid: z.string(),
+        bundleId: z.string(),
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+      ...DEFER_LOADING_CONFIG,
+    },
+    async args => {
+      try {
+        await validateXcodeInstallation();
+        return await simctlUninstallTool(args);
+      } catch (error) {
+        if (error instanceof McpError) throw error;
+        throw new McpError(
+          ErrorCode.InternalError,
+          `Tool execution failed: ${error instanceof Error ? error.message : String(error)}`
+        );
+      }
+    }
+  );
+
+  // simctl-launch
+  server.registerTool(
+    'simctl-launch',
+    {
+      title: 'Launch App on Simulator',
+      description: getDescription(SIMCTL_LAUNCH_DOCS, SIMCTL_LAUNCH_DOCS),
+      inputSchema: {
+        udid: z.string(),
+        bundleId: z.string(),
+        arguments: z.array(z.string()).optional(),
+        environment: z.record(z.string(), z.string()).optional(),
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: false,
+      },
+      ...DEFER_LOADING_CONFIG,
+    },
+    async args => {
+      try {
+        await validateXcodeInstallation();
+        return await simctlLaunchTool(args);
+      } catch (error) {
+        if (error instanceof McpError) throw error;
+        throw new McpError(
+          ErrorCode.InternalError,
+          `Tool execution failed: ${error instanceof Error ? error.message : String(error)}`
+        );
+      }
+    }
+  );
+
+  // simctl-terminate
+  server.registerTool(
+    'simctl-terminate',
+    {
+      title: 'Terminate App on Simulator',
+      description: getDescription(SIMCTL_TERMINATE_DOCS, SIMCTL_TERMINATE_DOCS),
+      inputSchema: {
+        udid: z.string(),
+        bundleId: z.string(),
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+      ...DEFER_LOADING_CONFIG,
+    },
+    async args => {
+      try {
+        await validateXcodeInstallation();
+        return await simctlTerminateTool(args);
       } catch (error) {
         if (error instanceof McpError) throw error;
         throw new McpError(
@@ -201,6 +520,7 @@ export function registerSimctlTools(server: McpServer): void {
   server.registerTool(
     'simctl-get-app-container',
     {
+      title: 'Get App Container Path',
       description: getDescription(
         SIMCTL_GET_APP_CONTAINER_DOCS,
         SIMCTL_GET_APP_CONTAINER_DOCS_MINI
@@ -209,6 +529,12 @@ export function registerSimctlTools(server: McpServer): void {
         udid: z.string(),
         bundleId: z.string(),
         containerType: z.enum(['bundle', 'data', 'group']).optional(),
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
       },
       ...DEFER_LOADING_CONFIG,
     },
@@ -230,10 +556,17 @@ export function registerSimctlTools(server: McpServer): void {
   server.registerTool(
     'simctl-openurl',
     {
+      title: 'Open URL on Simulator',
       description: getDescription(SIMCTL_OPENURL_DOCS, SIMCTL_OPENURL_DOCS_MINI),
       inputSchema: {
         udid: z.string(),
         url: z.string(),
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: false,
       },
       ...DEFER_LOADING_CONFIG,
     },
@@ -255,6 +588,7 @@ export function registerSimctlTools(server: McpServer): void {
   server.registerTool(
     'simctl-io',
     {
+      title: 'Simulator Screenshot/Video Capture',
       description: getDescription(SIMCTL_IO_DOCS, SIMCTL_IO_DOCS_MINI),
       inputSchema: {
         udid: z.string(),
@@ -265,6 +599,12 @@ export function registerSimctlTools(server: McpServer): void {
         appName: z.string().optional(),
         screenName: z.string().optional(),
         state: z.string().optional(),
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: false,
       },
       ...DEFER_LOADING_CONFIG,
     },
@@ -286,6 +626,7 @@ export function registerSimctlTools(server: McpServer): void {
   server.registerTool(
     'simctl-push',
     {
+      title: 'Send Push Notification',
       description: getDescription(SIMCTL_PUSH_DOCS, SIMCTL_PUSH_DOCS_MINI),
       inputSchema: {
         udid: z.string(),
@@ -293,6 +634,12 @@ export function registerSimctlTools(server: McpServer): void {
         payload: z.string(),
         testName: z.string().optional(),
         expectedBehavior: z.string().optional(),
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: false,
       },
       ...DEFER_LOADING_CONFIG,
     },
@@ -314,6 +661,7 @@ export function registerSimctlTools(server: McpServer): void {
   server.registerTool(
     'screenshot',
     {
+      title: 'Inline Simulator Screenshot',
       description: getDescription(
         SIMCTL_SCREENSHOT_INLINE_DOCS,
         SIMCTL_SCREENSHOT_INLINE_DOCS_MINI
@@ -325,6 +673,12 @@ export function registerSimctlTools(server: McpServer): void {
         screenName: z.string().optional(),
         state: z.string().optional(),
         enableCoordinateCaching: z.boolean().optional(),
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
       },
       ...DEFER_LOADING_CONFIG,
     },
@@ -346,10 +700,17 @@ export function registerSimctlTools(server: McpServer): void {
   server.registerTool(
     'simctl-addmedia',
     {
+      title: 'Add Media to Simulator',
       description: getDescription(SIMCTL_ADDMEDIA_DOCS, SIMCTL_ADDMEDIA_DOCS),
       inputSchema: {
         udid: z.string(),
         mediaPath: z.string(),
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: false,
       },
       ...DEFER_LOADING_CONFIG,
     },
@@ -371,10 +732,17 @@ export function registerSimctlTools(server: McpServer): void {
   server.registerTool(
     'simctl-pbcopy',
     {
+      title: 'Copy Text to Simulator Clipboard',
       description: getDescription(SIMCTL_PBCOPY_DOCS, SIMCTL_PBCOPY_DOCS),
       inputSchema: {
         udid: z.string(),
         text: z.string(),
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
       },
       ...DEFER_LOADING_CONFIG,
     },
@@ -396,6 +764,7 @@ export function registerSimctlTools(server: McpServer): void {
   server.registerTool(
     'simctl-privacy',
     {
+      title: 'Manage App Privacy Permissions',
       description: getDescription(SIMCTL_PRIVACY_DOCS, SIMCTL_PRIVACY_DOCS),
       inputSchema: {
         udid: z.string(),
@@ -404,6 +773,12 @@ export function registerSimctlTools(server: McpServer): void {
         service: z.string(),
         scenario: z.string().optional(),
         step: z.number().optional(),
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
       },
       ...DEFER_LOADING_CONFIG,
     },
@@ -425,6 +800,7 @@ export function registerSimctlTools(server: McpServer): void {
   server.registerTool(
     'simctl-status-bar',
     {
+      title: 'Override Simulator Status Bar',
       description: getDescription(SIMCTL_STATUS_BAR_DOCS, SIMCTL_STATUS_BAR_DOCS),
       inputSchema: {
         udid: z.string(),
@@ -434,6 +810,12 @@ export function registerSimctlTools(server: McpServer): void {
         wifiMode: z.string().optional(),
         batteryState: z.string().optional(),
         batteryLevel: z.number().optional(),
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
       },
       ...DEFER_LOADING_CONFIG,
     },
@@ -455,6 +837,7 @@ export function registerSimctlTools(server: McpServer): void {
   server.registerTool(
     'simctl-stream-logs',
     {
+      title: 'Stream Simulator Logs',
       description: getDescription(SIMCTL_STREAM_LOGS_DOCS, SIMCTL_STREAM_LOGS_DOCS),
       inputSchema: {
         udid: z.string(),
@@ -462,6 +845,12 @@ export function registerSimctlTools(server: McpServer): void {
         predicate: z.string().optional(),
         duration: z.number().optional(),
         capture: z.boolean().optional(),
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
       },
       ...DEFER_LOADING_CONFIG,
     },
@@ -483,12 +872,19 @@ export function registerSimctlTools(server: McpServer): void {
   server.registerTool(
     'simctl-suggest',
     {
+      title: 'Suggest Best Simulator',
       description: getDescription(SIMCTL_SUGGEST_DOCS, SIMCTL_SUGGEST_DOCS),
       inputSchema: {
         projectPath: z.string().optional(),
         deviceType: z.string().optional(),
         maxSuggestions: z.number().optional(),
         autoBootTopSuggestion: z.boolean().optional(),
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
       },
       ...DEFER_LOADING_CONFIG,
     },

--- a/src/registry/system.ts
+++ b/src/registry/system.ts
@@ -15,10 +15,17 @@ export function registerSystemTools(server: McpServer): void {
   server.registerTool(
     'rtfm',
     {
+      title: 'Read The Manual (Tool Docs)',
       description: getDescription(RTFM_DOCS, RTFM_DOCS_MINI),
       inputSchema: {
         toolName: z.string().optional(),
         categoryName: z.string().optional(),
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
       },
       ...DEFER_LOADING_CONFIG,
     },

--- a/src/registry/workflows.ts
+++ b/src/registry/workflows.ts
@@ -29,6 +29,7 @@ export function registerWorkflowTools(server: McpServer): void {
   server.registerTool(
     'workflow-tap-element',
     {
+      title: 'Tap Element (Workflow)',
       description: getDescription(WORKFLOW_TAP_ELEMENT_DOCS, WORKFLOW_TAP_ELEMENT_DOCS_MINI),
       inputSchema: {
         elementQuery: z.string().describe('Search term for element (e.g., "Login", "Submit")'),
@@ -36,6 +37,12 @@ export function registerWorkflowTools(server: McpServer): void {
         verifyResult: z.boolean().default(false).describe('Take screenshot after action'),
         udid: z.string().optional().describe('Target device'),
         screenContext: z.string().optional().describe('Screen name for tracking'),
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: false,
       },
       ...DEFER_LOADING_CONFIG,
     },
@@ -57,6 +64,7 @@ export function registerWorkflowTools(server: McpServer): void {
   server.registerTool(
     'workflow-fresh-install',
     {
+      title: 'Fresh Install (Workflow)',
       description: getDescription(WORKFLOW_FRESH_INSTALL_DOCS, WORKFLOW_FRESH_INSTALL_DOCS_MINI),
       inputSchema: {
         projectPath: z.string().describe('Path to .xcodeproj or .xcworkspace'),
@@ -66,6 +74,12 @@ export function registerWorkflowTools(server: McpServer): void {
         configuration: z.enum(['Debug', 'Release']).default('Debug'),
         launchArguments: z.array(z.string()).optional(),
         environmentVariables: z.record(z.string(), z.string()).optional(),
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: false,
+        openWorldHint: false,
       },
       ...DEFER_LOADING_CONFIG,
     },
@@ -87,6 +101,7 @@ export function registerWorkflowTools(server: McpServer): void {
   server.registerTool(
     'workflow-build-and-run',
     {
+      title: 'Build & Run (Workflow)',
       description: getDescription(BUILD_AND_RUN_DOCS, BUILD_AND_RUN_DOCS_MINI),
       inputSchema: {
         projectPath: z.string().describe('Path to .xcodeproj or .xcworkspace'),
@@ -102,6 +117,12 @@ export function registerWorkflowTools(server: McpServer): void {
           .optional()
           .describe('App environment variables'),
         takeScreenshot: z.boolean().optional().describe('Capture screenshot after launch'),
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: false,
       },
       ...DEFER_LOADING_CONFIG,
     },

--- a/src/registry/workflows.ts
+++ b/src/registry/workflows.ts
@@ -13,6 +13,11 @@ import {
   WORKFLOW_FRESH_INSTALL_DOCS,
   WORKFLOW_FRESH_INSTALL_DOCS_MINI,
 } from '../tools/workflows/fresh-install.js';
+import {
+  buildAndRunTool,
+  BUILD_AND_RUN_DOCS,
+  BUILD_AND_RUN_DOCS_MINI,
+} from '../tools/workflows/build-and-run.js';
 
 const ENABLE_DEFER_LOADING = process.env.XC_MCP_DEFER_LOADING !== 'false';
 const DEFER_LOADING_CONFIG = ENABLE_DEFER_LOADING
@@ -68,6 +73,42 @@ export function registerWorkflowTools(server: McpServer): void {
       try {
         await validateXcodeInstallation();
         return await workflowFreshInstallTool(args);
+      } catch (error) {
+        if (error instanceof McpError) throw error;
+        throw new McpError(
+          ErrorCode.InternalError,
+          `Tool execution failed: ${error instanceof Error ? error.message : String(error)}`
+        );
+      }
+    }
+  );
+
+  // workflow-build-and-run
+  server.registerTool(
+    'workflow-build-and-run',
+    {
+      description: getDescription(BUILD_AND_RUN_DOCS, BUILD_AND_RUN_DOCS_MINI),
+      inputSchema: {
+        projectPath: z.string().describe('Path to .xcodeproj or .xcworkspace'),
+        scheme: z.string().describe('Build scheme name'),
+        configuration: z.string().optional().describe('Build configuration (default: "Debug")'),
+        simulatorUdid: z
+          .string()
+          .optional()
+          .describe('Target simulator UDID - auto-detected if omitted'),
+        launchArguments: z.array(z.string()).optional().describe('App launch arguments'),
+        environmentVariables: z
+          .record(z.string(), z.string())
+          .optional()
+          .describe('App environment variables'),
+        takeScreenshot: z.boolean().optional().describe('Capture screenshot after launch'),
+      },
+      ...DEFER_LOADING_CONFIG,
+    },
+    async args => {
+      try {
+        await validateXcodeInstallation();
+        return await buildAndRunTool(args);
       } catch (error) {
         if (error instanceof McpError) throw error;
         throw new McpError(

--- a/src/registry/workflows.ts
+++ b/src/registry/workflows.ts
@@ -60,7 +60,7 @@ export function registerWorkflowTools(server: McpServer): void {
         eraseSimulator: z.boolean().default(false).describe('Wipe simulator data'),
         configuration: z.enum(['Debug', 'Release']).default('Debug'),
         launchArguments: z.array(z.string()).optional(),
-        environmentVariables: z.record(z.string()).optional(),
+        environmentVariables: z.record(z.string(), z.string()).optional(),
       },
       ...DEFER_LOADING_CONFIG,
     },

--- a/src/registry/xcodebuild.ts
+++ b/src/registry/xcodebuild.ts
@@ -129,6 +129,15 @@ export function registerXcodebuildTools(server: McpServer): void {
         sdk: z.string().optional(),
         derivedDataPath: z.string().optional(),
       },
+      outputSchema: {
+        buildId: z.string().describe('Cache id for full build log (xcodebuild-get-details)'),
+        success: z.boolean(),
+        errorCount: z.number(),
+        warningCount: z.number(),
+        durationMs: z.number(),
+        scheme: z.string(),
+        configuration: z.string(),
+      },
       annotations: {
         readOnlyHint: false,
         destructiveHint: false,
@@ -201,6 +210,16 @@ export function registerXcodebuildTools(server: McpServer): void {
         onlyTesting: z.array(z.string()).optional(),
         skipTesting: z.array(z.string()).optional(),
         testWithoutBuilding: z.boolean().default(false),
+      },
+      outputSchema: {
+        testId: z.string().describe('Cache id for full test log (xcodebuild-get-details)'),
+        success: z.boolean(),
+        totalTests: z.number(),
+        passed: z.number(),
+        failed: z.number(),
+        skipped: z.number(),
+        durationMs: z.number().optional(),
+        scheme: z.string(),
       },
       annotations: {
         readOnlyHint: false,

--- a/src/registry/xcodebuild.ts
+++ b/src/registry/xcodebuild.ts
@@ -55,10 +55,17 @@ export function registerXcodebuildTools(server: McpServer): void {
   server.registerTool(
     'xcodebuild-version',
     {
+      title: 'Xcode Version Info',
       description: getDescription(XCODEBUILD_VERSION_DOCS, XCODEBUILD_VERSION_DOCS_MINI),
       inputSchema: {
         sdk: z.string().optional(),
         outputFormat: z.enum(['json', 'text']).default('json'),
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
       },
       ...DEFER_LOADING_CONFIG,
     },
@@ -80,10 +87,17 @@ export function registerXcodebuildTools(server: McpServer): void {
   server.registerTool(
     'xcodebuild-list',
     {
+      title: 'List Xcode Schemes & Targets',
       description: getDescription(XCODEBUILD_LIST_DOCS, XCODEBUILD_LIST_DOCS_MINI),
       inputSchema: {
         projectPath: z.string(),
         outputFormat: z.enum(['json', 'text']).default('json'),
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
       },
       ...DEFER_LOADING_CONFIG,
     },
@@ -105,6 +119,7 @@ export function registerXcodebuildTools(server: McpServer): void {
   server.registerTool(
     'xcodebuild-build',
     {
+      title: 'Build Xcode Scheme',
       description: getDescription(XCODEBUILD_BUILD_DOCS, XCODEBUILD_BUILD_DOCS_MINI),
       inputSchema: {
         projectPath: z.string(),
@@ -113,6 +128,12 @@ export function registerXcodebuildTools(server: McpServer): void {
         destination: z.string().optional(),
         sdk: z.string().optional(),
         derivedDataPath: z.string().optional(),
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: false,
       },
       ...DEFER_LOADING_CONFIG,
     },
@@ -134,11 +155,18 @@ export function registerXcodebuildTools(server: McpServer): void {
   server.registerTool(
     'xcodebuild-clean',
     {
+      title: 'Clean Xcode Build',
       description: getDescription(XCODEBUILD_CLEAN_DOCS, XCODEBUILD_CLEAN_DOCS_MINI),
       inputSchema: {
         projectPath: z.string(),
         scheme: z.string(),
         configuration: z.string().optional(),
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: true,
+        openWorldHint: false,
       },
       ...DEFER_LOADING_CONFIG,
     },
@@ -160,6 +188,7 @@ export function registerXcodebuildTools(server: McpServer): void {
   server.registerTool(
     'xcodebuild-test',
     {
+      title: 'Run Xcode Tests',
       description: getDescription(XCODEBUILD_TEST_DOCS, XCODEBUILD_TEST_DOCS_MINI),
       inputSchema: {
         projectPath: z.string(),
@@ -172,6 +201,12 @@ export function registerXcodebuildTools(server: McpServer): void {
         onlyTesting: z.array(z.string()).optional(),
         skipTesting: z.array(z.string()).optional(),
         testWithoutBuilding: z.boolean().default(false),
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: false,
       },
       ...DEFER_LOADING_CONFIG,
     },
@@ -193,6 +228,7 @@ export function registerXcodebuildTools(server: McpServer): void {
   server.registerTool(
     'xcodebuild-get-details',
     {
+      title: 'Get Build/Test Details',
       description: getDescription(XCODEBUILD_GET_DETAILS_DOCS, XCODEBUILD_GET_DETAILS_DOCS_MINI),
       inputSchema: {
         buildId: z.string(),
@@ -205,6 +241,12 @@ export function registerXcodebuildTools(server: McpServer): void {
           'metadata',
         ]),
         maxLines: z.number().default(100),
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
       },
       ...DEFER_LOADING_CONFIG,
     },
@@ -226,9 +268,16 @@ export function registerXcodebuildTools(server: McpServer): void {
   server.registerTool(
     'xcodebuild-showsdks',
     {
+      title: 'List Available SDKs',
       description: getDescription(XCODEBUILD_SHOWSDKS_DOCS, XCODEBUILD_SHOWSDKS_DOCS),
       inputSchema: {
         outputFormat: z.enum(['json', 'text']).default('json'),
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
       },
       ...DEFER_LOADING_CONFIG,
     },
@@ -254,9 +303,16 @@ export function registerXcodebuildTools(server: McpServer): void {
         XCODEBUILD_INSPECT_SCHEME_DOCS,
         XCODEBUILD_INSPECT_SCHEME_DOCS_MINI
       ),
+      title: 'Inspect Xcode Scheme',
       inputSchema: {
         projectPath: z.string(),
         scheme: z.string(),
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
       },
       ...DEFER_LOADING_CONFIG,
     },
@@ -282,10 +338,17 @@ export function registerXcodebuildTools(server: McpServer): void {
         XCODEBUILD_VALIDATE_CAPABILITIES_DOCS,
         XCODEBUILD_VALIDATE_CAPABILITIES_DOCS_MINI
       ),
+      title: 'Validate App Capabilities',
       inputSchema: {
         projectPath: z.string(),
         scheme: z.string(),
         udid: z.string().optional(),
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
       },
       ...DEFER_LOADING_CONFIG,
     },

--- a/src/registry/xcodebuild.ts
+++ b/src/registry/xcodebuild.ts
@@ -33,6 +33,17 @@ import {
   XCODEBUILD_GET_DETAILS_DOCS,
   XCODEBUILD_GET_DETAILS_DOCS_MINI,
 } from '../tools/xcodebuild/get-details.js';
+import { xcodebuildShowSDKsTool, XCODEBUILD_SHOWSDKS_DOCS } from '../tools/xcodebuild/showsdks.js';
+import {
+  inspectSchemeTool,
+  XCODEBUILD_INSPECT_SCHEME_DOCS,
+  XCODEBUILD_INSPECT_SCHEME_DOCS_MINI,
+} from '../tools/xcodebuild/inspect-scheme.js';
+import {
+  validateCapabilitiesTool,
+  XCODEBUILD_VALIDATE_CAPABILITIES_DOCS,
+  XCODEBUILD_VALIDATE_CAPABILITIES_DOCS_MINI,
+} from '../tools/xcodebuild/validate-capabilities.js';
 
 const ENABLE_DEFER_LOADING = process.env.XC_MCP_DEFER_LOADING !== 'false';
 const DEFER_LOADING_CONFIG = ENABLE_DEFER_LOADING
@@ -201,6 +212,87 @@ export function registerXcodebuildTools(server: McpServer): void {
       try {
         await validateXcodeInstallation();
         return await xcodebuildGetDetailsTool(args);
+      } catch (error) {
+        if (error instanceof McpError) throw error;
+        throw new McpError(
+          ErrorCode.InternalError,
+          `Tool execution failed: ${error instanceof Error ? error.message : String(error)}`
+        );
+      }
+    }
+  );
+
+  // xcodebuild-showsdks
+  server.registerTool(
+    'xcodebuild-showsdks',
+    {
+      description: getDescription(XCODEBUILD_SHOWSDKS_DOCS, XCODEBUILD_SHOWSDKS_DOCS),
+      inputSchema: {
+        outputFormat: z.enum(['json', 'text']).default('json'),
+      },
+      ...DEFER_LOADING_CONFIG,
+    },
+    async args => {
+      try {
+        await validateXcodeInstallation();
+        return await xcodebuildShowSDKsTool(args);
+      } catch (error) {
+        if (error instanceof McpError) throw error;
+        throw new McpError(
+          ErrorCode.InternalError,
+          `Tool execution failed: ${error instanceof Error ? error.message : String(error)}`
+        );
+      }
+    }
+  );
+
+  // xcodebuild-inspect-scheme
+  server.registerTool(
+    'xcodebuild-inspect-scheme',
+    {
+      description: getDescription(
+        XCODEBUILD_INSPECT_SCHEME_DOCS,
+        XCODEBUILD_INSPECT_SCHEME_DOCS_MINI
+      ),
+      inputSchema: {
+        projectPath: z.string(),
+        scheme: z.string(),
+      },
+      ...DEFER_LOADING_CONFIG,
+    },
+    async args => {
+      try {
+        await validateXcodeInstallation();
+        return await inspectSchemeTool(args);
+      } catch (error) {
+        if (error instanceof McpError) throw error;
+        throw new McpError(
+          ErrorCode.InternalError,
+          `Tool execution failed: ${error instanceof Error ? error.message : String(error)}`
+        );
+      }
+    }
+  );
+
+  // xcodebuild-validate-capabilities
+  server.registerTool(
+    'xcodebuild-validate-capabilities',
+    {
+      description: getDescription(
+        XCODEBUILD_VALIDATE_CAPABILITIES_DOCS,
+        XCODEBUILD_VALIDATE_CAPABILITIES_DOCS_MINI
+      ),
+      inputSchema: {
+        projectPath: z.string(),
+        scheme: z.string(),
+        udid: z.string().optional(),
+      },
+      ...DEFER_LOADING_CONFIG,
+    },
+    async args => {
+      try {
+        await validateXcodeInstallation();
+        return await validateCapabilitiesTool(args);
       } catch (error) {
         if (error instanceof McpError) throw error;
         throw new McpError(

--- a/src/tools/docs-registry.ts
+++ b/src/tools/docs-registry.ts
@@ -53,6 +53,9 @@ import { CACHE_LIST_CACHED_RESPONSES_DOCS } from './cache/list-cached.js';
 // Workflow documentation (v3.0.0)
 import { WORKFLOW_TAP_ELEMENT_DOCS } from './workflows/tap-element.js';
 import { WORKFLOW_FRESH_INSTALL_DOCS } from './workflows/fresh-install.js';
+import { BUILD_AND_RUN_DOCS } from './workflows/build-and-run.js';
+import { XCODEBUILD_INSPECT_SCHEME_DOCS } from './xcodebuild/inspect-scheme.js';
+import { XCODEBUILD_VALIDATE_CAPABILITIES_DOCS } from './xcodebuild/validate-capabilities.js';
 
 // Consolidated router documentation (v2.0+)
 import { SIMCTL_DEVICE_DOCS } from './simctl/device/index.js';
@@ -413,6 +416,8 @@ export const TOOL_CATEGORIES: Record<string, string[]> = {
     'xcodebuild-clean',
     'xcodebuild-test',
     'xcodebuild-get-details',
+    'xcodebuild-inspect-scheme',
+    'xcodebuild-validate-capabilities',
   ],
   simulator: [
     'simctl-list',
@@ -452,7 +457,6 @@ export const TOOL_CATEGORIES: Record<string, string[]> = {
     // MANAGEMENT TOOLS - App and target management
     // ============================================================================
     'idb-targets',
-    'idb-connect',
     'idb-list-apps',
     'idb-install',
     'idb-launch',
@@ -460,7 +464,13 @@ export const TOOL_CATEGORIES: Record<string, string[]> = {
     'idb-uninstall',
   ],
   io: ['simctl-io', 'simctl-addmedia', 'screenshot'],
-  testing: ['simctl-privacy', 'simctl-push', 'simctl-pbcopy', 'simctl-status-bar'],
+  testing: [
+    'simctl-privacy',
+    'simctl-push',
+    'simctl-pbcopy',
+    'simctl-status-bar',
+    'simctl-stream-logs',
+  ],
   cache: [
     'list-cached-responses',
     'cache-get-stats',
@@ -475,7 +485,7 @@ export const TOOL_CATEGORIES: Record<string, string[]> = {
     'rtfm',
     'screenshot-save',
   ],
-  workflow: ['workflow-tap-element', 'workflow-fresh-install'],
+  workflow: ['workflow-tap-element', 'workflow-fresh-install', 'workflow-build-and-run'],
 };
 
 export const CATEGORY_DESCRIPTIONS: Record<string, { name: string; description: string }> = {
@@ -556,6 +566,8 @@ export const TOOL_DOCS: Record<string, string> = {
   'xcodebuild-version': XCODEBUILD_VERSION_DOCS,
   'xcodebuild-get-details': XCODEBUILD_GET_DETAILS_DOCS,
   'xcodebuild-test': XCODEBUILD_TEST_DOCS,
+  'xcodebuild-inspect-scheme': XCODEBUILD_INSPECT_SCHEME_DOCS,
+  'xcodebuild-validate-capabilities': XCODEBUILD_VALIDATE_CAPABILITIES_DOCS,
 
   // Simctl lifecycle tools (non-consolidated)
   'simctl-list': SIMCTL_LIST_DOCS,
@@ -603,6 +615,7 @@ export const TOOL_DOCS: Record<string, string> = {
   // Workflow tools (v3.0.0)
   'workflow-tap-element': WORKFLOW_TAP_ELEMENT_DOCS,
   'workflow-fresh-install': WORKFLOW_FRESH_INSTALL_DOCS,
+  'workflow-build-and-run': BUILD_AND_RUN_DOCS,
 
   // Backwards compatibility aliases (v1.x tools → v2.0 consolidated tools)
   // Simctl device consolidation

--- a/src/tools/docs-registry.ts
+++ b/src/tools/docs-registry.ts
@@ -56,6 +56,29 @@ import { WORKFLOW_FRESH_INSTALL_DOCS } from './workflows/fresh-install.js';
 import { BUILD_AND_RUN_DOCS } from './workflows/build-and-run.js';
 import { XCODEBUILD_INSPECT_SCHEME_DOCS } from './xcodebuild/inspect-scheme.js';
 import { XCODEBUILD_VALIDATE_CAPABILITIES_DOCS } from './xcodebuild/validate-capabilities.js';
+// Discrete tool docs (v4 — routers dissolved into discrete tools)
+import { SIMCTL_BOOT_DOCS } from './simctl/boot.js';
+import { SIMCTL_SHUTDOWN_DOCS } from './simctl/shutdown.js';
+import { SIMCTL_CREATE_DOCS } from './simctl/create.js';
+import { SIMCTL_DELETE_DOCS } from './simctl/delete.js';
+import { SIMCTL_ERASE_DOCS } from './simctl/erase.js';
+import { SIMCTL_CLONE_DOCS } from './simctl/clone.js';
+import { SIMCTL_RENAME_DOCS } from './simctl/rename.js';
+import { SIMCTL_INSTALL_DOCS } from './simctl/install.js';
+import { SIMCTL_UNINSTALL_DOCS } from './simctl/uninstall.js';
+import { SIMCTL_LAUNCH_DOCS } from './simctl/launch.js';
+import { SIMCTL_TERMINATE_DOCS } from './simctl/terminate.js';
+import { IDB_INSTALL_DOCS } from './idb/install.js';
+import { IDB_UNINSTALL_DOCS } from './idb/uninstall.js';
+import { IDB_LAUNCH_DOCS } from './idb/launch.js';
+import { IDB_TERMINATE_DOCS } from './idb/terminate.js';
+import { CACHE_GET_STATS_DOCS } from './cache/get-stats.js';
+import { CACHE_GET_CONFIG_DOCS } from './cache/get-config.js';
+import { CACHE_SET_CONFIG_DOCS } from './cache/set-config.js';
+import { CACHE_CLEAR_DOCS } from './cache/clear.js';
+import { PERSISTENCE_ENABLE_DOCS } from './persistence/enable.js';
+import { PERSISTENCE_DISABLE_DOCS } from './persistence/disable.js';
+import { PERSISTENCE_STATUS_DOCS } from './persistence/status.js';
 
 // Consolidated router documentation (v2.0+)
 import { SIMCTL_DEVICE_DOCS } from './simctl/device/index.js';
@@ -617,38 +640,38 @@ export const TOOL_DOCS: Record<string, string> = {
   'workflow-fresh-install': WORKFLOW_FRESH_INSTALL_DOCS,
   'workflow-build-and-run': BUILD_AND_RUN_DOCS,
 
-  // Backwards compatibility aliases (v1.x tools → v2.0 consolidated tools)
-  // Simctl device consolidation
-  'simctl-boot': SIMCTL_DEVICE_DOCS,
-  'simctl-shutdown': SIMCTL_DEVICE_DOCS,
-  'simctl-create': SIMCTL_DEVICE_DOCS,
-  'simctl-delete': SIMCTL_DEVICE_DOCS,
-  'simctl-erase': SIMCTL_DEVICE_DOCS,
-  'simctl-clone': SIMCTL_DEVICE_DOCS,
-  'simctl-rename': SIMCTL_DEVICE_DOCS,
+  // Discrete tools (v4 — dissolved from v2/v3 routers, each documents its own usage)
+  // Simctl device lifecycle
+  'simctl-boot': SIMCTL_BOOT_DOCS,
+  'simctl-shutdown': SIMCTL_SHUTDOWN_DOCS,
+  'simctl-create': SIMCTL_CREATE_DOCS,
+  'simctl-delete': SIMCTL_DELETE_DOCS,
+  'simctl-erase': SIMCTL_ERASE_DOCS,
+  'simctl-clone': SIMCTL_CLONE_DOCS,
+  'simctl-rename': SIMCTL_RENAME_DOCS,
 
-  // Simctl app consolidation
-  'simctl-install': SIMCTL_APP_DOCS,
-  'simctl-uninstall': SIMCTL_APP_DOCS,
-  'simctl-launch': SIMCTL_APP_DOCS,
-  'simctl-terminate': SIMCTL_APP_DOCS,
+  // Simctl app lifecycle
+  'simctl-install': SIMCTL_INSTALL_DOCS,
+  'simctl-uninstall': SIMCTL_UNINSTALL_DOCS,
+  'simctl-launch': SIMCTL_LAUNCH_DOCS,
+  'simctl-terminate': SIMCTL_TERMINATE_DOCS,
 
-  // IDB app consolidation
-  'idb-install': IDB_APP_DOCS,
-  'idb-uninstall': IDB_APP_DOCS,
-  'idb-launch': IDB_APP_DOCS,
-  'idb-terminate': IDB_APP_DOCS,
+  // IDB app lifecycle
+  'idb-install': IDB_INSTALL_DOCS,
+  'idb-uninstall': IDB_UNINSTALL_DOCS,
+  'idb-launch': IDB_LAUNCH_DOCS,
+  'idb-terminate': IDB_TERMINATE_DOCS,
 
-  // Cache consolidation
-  'cache-get-stats': CACHE_DOCS,
-  'cache-get-config': CACHE_DOCS,
-  'cache-set-config': CACHE_DOCS,
-  'cache-clear': CACHE_DOCS,
+  // Cache management
+  'cache-get-stats': CACHE_GET_STATS_DOCS,
+  'cache-get-config': CACHE_GET_CONFIG_DOCS,
+  'cache-set-config': CACHE_SET_CONFIG_DOCS,
+  'cache-clear': CACHE_CLEAR_DOCS,
 
-  // Persistence consolidation
-  'persistence-enable': PERSISTENCE_DOCS,
-  'persistence-disable': PERSISTENCE_DOCS,
-  'persistence-status': PERSISTENCE_DOCS,
+  // Persistence
+  'persistence-enable': PERSISTENCE_ENABLE_DOCS,
+  'persistence-disable': PERSISTENCE_DISABLE_DOCS,
+  'persistence-status': PERSISTENCE_STATUS_DOCS,
 
   // Tool aliases
   'screenshot-save': SCREENSHOT_SAVE_DOCS,

--- a/src/tools/idb/accessibility-quality-check.ts
+++ b/src/tools/idb/accessibility-quality-check.ts
@@ -229,6 +229,14 @@ export async function accessibilityQualityCheckTool(args: AccessibilityQualityCh
           ),
         },
       ],
+      structuredContent: {
+        success: true,
+        quality: assessment.quality,
+        recommendation,
+        totalElements: assessment.totalElements,
+        tappableElements: assessment.tappableCount,
+        textFields: assessment.textFieldCount,
+      },
       isError: false,
     };
   } catch (error) {

--- a/src/tools/idb/ui-describe.ts
+++ b/src/tools/idb/ui-describe.ts
@@ -2,7 +2,7 @@ import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
 import { executeCommand } from '../../utils/command.js';
 import { resolveIdbUdid, validateTargetBooted } from '../../utils/idb-device-detection.js';
 import { IDBTargetCache } from '../../state/idb-target-cache.js';
-import { responseCache } from '../../utils/response-cache.js';
+import { responseCache, responseResourceLink } from '../../utils/response-cache.js';
 import { formatToolError } from '../../utils/error-formatter.js';
 import { parseFlexibleJson } from '../../utils/json-parser.js';
 
@@ -163,6 +163,15 @@ export async function idbUiDescribeTool(args: IdbUiDescribeArgs) {
             2
           ),
         },
+        ...(result.uiTreeId
+          ? [
+              responseResourceLink(
+                result.uiTreeId,
+                'idb-ui-describe',
+                `Full accessibility tree${result.targetName ? ` for ${result.targetName}` : ''}`
+              ),
+            ]
+          : []),
       ],
       isError: !result.success,
     };

--- a/src/tools/simctl/list.ts
+++ b/src/tools/simctl/list.ts
@@ -9,6 +9,7 @@ import {
   responseCache,
   extractSimulatorSummary,
   createProgressiveSimulatorResponse,
+  responseResourceLink,
 } from '../../utils/response-cache.js';
 
 interface SimctlListArgs {
@@ -83,6 +84,9 @@ export async function simctlListTool(args: any) {
 
     let responseData: Record<string, unknown> | string;
 
+    // Cache id for the full simulator list, set only in concise/progressive mode
+    let resourceCacheId: string | undefined;
+
     // Use progressive disclosure by default (concise=true)
     if (concise && outputFormat === 'json') {
       // Generate concise summary
@@ -108,6 +112,7 @@ export async function simctlListTool(args: any) {
         runtime,
         availability,
       });
+      resourceCacheId = cacheId;
     } else {
       // Legacy mode: return full filtered list with device limiting
       if (outputFormat === 'json') {
@@ -178,6 +183,15 @@ export async function simctlListTool(args: any) {
           type: 'text' as const,
           text: responseText,
         },
+        ...(resourceCacheId
+          ? [
+              responseResourceLink(
+                resourceCacheId,
+                'simctl-list',
+                'Full simulator list (all devices, runtimes, and device types)'
+              ),
+            ]
+          : []),
       ],
     };
   } catch (error) {

--- a/src/tools/workflows/build-and-run.ts
+++ b/src/tools/workflows/build-and-run.ts
@@ -1,5 +1,37 @@
 import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
 
+export const BUILD_AND_RUN_DOCS = `
+# workflow-build-and-run
+
+Build and run an Xcode project on a simulator in a single orchestrated workflow.
+
+## Overview
+
+Combines build, simulator selection, installation, and launch into one call:
+1. **Build** - Compile the Xcode project with xcodebuild
+2. **Select Simulator** - Auto-detect or use specified device
+3. **Boot** - Start the simulator
+4. **Install** - Install the built .app bundle
+5. **Launch** - Launch the app
+6. **Screenshot** (optional) - Capture initial app state
+
+## Parameters
+
+### Required
+- **projectPath** (string): Path to .xcodeproj or .xcworkspace
+- **scheme** (string): Build scheme name
+
+### Optional
+- **configuration** (string): Build configuration (default: "Debug")
+- **simulatorUdid** (string): Target simulator UDID - auto-detected if omitted
+- **launchArguments** (string[]): App launch arguments
+- **environmentVariables** (Record<string, string>): App environment variables
+- **takeScreenshot** (boolean): Capture screenshot after launch (default: false)
+`;
+
+export const BUILD_AND_RUN_DOCS_MINI =
+  'Build, install and launch app on simulator. Use rtfm({ toolName: "workflow-build-and-run" }) for docs.';
+
 /**
  * Build and Run Workflow Orchestration
  *

--- a/src/tools/workflows/build-and-run.ts
+++ b/src/tools/workflows/build-and-run.ts
@@ -86,7 +86,11 @@ export async function buildAndRunTool(args: any) {
         autoInstall: false, // We'll handle install manually in workflow
       });
 
-      const buildText = buildResult.content?.[0]?.text || JSON.stringify(buildResult);
+      const buildTextBlock = buildResult.content?.find(c => c.type === 'text');
+      const buildText =
+        buildTextBlock && 'text' in buildTextBlock
+          ? buildTextBlock.text
+          : JSON.stringify(buildResult);
       const buildData = typeof buildText === 'string' ? JSON.parse(buildText) : buildText;
 
       workflow.steps.push({

--- a/src/tools/workflows/fresh-install.ts
+++ b/src/tools/workflows/fresh-install.ts
@@ -225,7 +225,11 @@ export async function workflowFreshInstallTool(args: FreshInstallArgs) {
         autoInstall: false, // We handle install manually
       });
 
-      const buildText = buildResult.content?.[0]?.text || JSON.stringify(buildResult);
+      const buildTextBlock = buildResult.content?.find(c => c.type === 'text');
+      const buildText =
+        buildTextBlock && 'text' in buildTextBlock
+          ? buildTextBlock.text
+          : JSON.stringify(buildResult);
       const buildData = typeof buildText === 'string' ? JSON.parse(buildText) : buildText;
 
       if (!buildData.success) {

--- a/src/tools/xcodebuild/build.ts
+++ b/src/tools/xcodebuild/build.ts
@@ -262,6 +262,15 @@ export async function xcodebuildBuildTool(args: any) {
           `Full build log for scheme "${finalConfig.scheme}" (${summary.success ? 'succeeded' : 'failed'})`
         ),
       ],
+      structuredContent: {
+        buildId: cacheId,
+        success: summary.success,
+        errorCount: summary.errorCount,
+        warningCount: summary.warningCount,
+        durationMs: duration,
+        scheme: finalConfig.scheme,
+        configuration: finalConfig.configuration,
+      },
       isError: !summary.success,
     };
   } catch (error) {

--- a/src/tools/xcodebuild/build.ts
+++ b/src/tools/xcodebuild/build.ts
@@ -1,7 +1,11 @@
 import { validateProjectPath, validateScheme } from '../../utils/validation.js';
 import { executeCommand, buildXcodebuildCommand } from '../../utils/command.js';
 import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
-import { responseCache, extractBuildSummary } from '../../utils/response-cache.js';
+import {
+  responseCache,
+  extractBuildSummary,
+  responseResourceLink,
+} from '../../utils/response-cache.js';
 import { projectCache, type BuildConfig } from '../../state/project-cache.js';
 import { simulatorCache } from '../../state/simulator-cache.js';
 import { createConfigManager } from '../../utils/config.js';
@@ -252,6 +256,11 @@ export async function xcodebuildBuildTool(args: any) {
           type: 'text' as const,
           text: responseText,
         },
+        responseResourceLink(
+          cacheId,
+          'xcodebuild-build',
+          `Full build log for scheme "${finalConfig.scheme}" (${summary.success ? 'succeeded' : 'failed'})`
+        ),
       ],
       isError: !summary.success,
     };

--- a/src/tools/xcodebuild/inspect-scheme.ts
+++ b/src/tools/xcodebuild/inspect-scheme.ts
@@ -2,12 +2,26 @@ import { readFileSync } from 'fs';
 import { basename, dirname } from 'path';
 import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
 
+export const XCODEBUILD_INSPECT_SCHEME_DOCS = `# xcodebuild-inspect-scheme
+
+Parse and display an Xcode scheme's build, run, and test configurations from its
+\`.xcscheme\` file.
+
+## Parameters
+- \`projectPath\` (required): Path to the .xcodeproj or .xcworkspace
+- \`scheme\` (required): Scheme name to inspect
+
+## Returns
+Parsed scheme information: build targets, run configuration, test configuration,
+and environment/launch arguments where present.`;
+
+export const XCODEBUILD_INSPECT_SCHEME_DOCS_MINI =
+  'Inspect Xcode scheme build/run/test configurations.';
+
 /**
  * Inspect Xcode Scheme Configuration
  *
  * Parse and display scheme build, run, and test configurations
- *
- * Full documentation: See src/tools/xcodebuild/inspect-scheme.md
  *
  * @param args Tool arguments
  * @returns Parsed scheme information

--- a/src/tools/xcodebuild/validate-capabilities.ts
+++ b/src/tools/xcodebuild/validate-capabilities.ts
@@ -1,11 +1,25 @@
 import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
 
+export const XCODEBUILD_VALIDATE_CAPABILITIES_DOCS = `# xcodebuild-validate-capabilities
+
+Compare an app's Info.plist required permissions/capabilities against the
+permissions actually granted on a simulator, surfacing mismatches.
+
+## Parameters
+- \`projectPath\` (required): Path to the .xcodeproj or .xcworkspace
+- \`scheme\` (required): Scheme name
+- \`udid\` (optional): Simulator UDID to validate granted permissions against
+
+## Returns
+A capabilities validation report listing required vs granted permissions and any gaps.`;
+
+export const XCODEBUILD_VALIDATE_CAPABILITIES_DOCS_MINI =
+  'Validate app capabilities against project Info.plist requirements.';
+
 /**
  * Validate App Capabilities Against Project
  *
  * Compare Info.plist required permissions with simulator granted permissions
- *
- * Full documentation: See src/tools/xcodebuild/validate-capabilities.md
  *
  * @param args Tool arguments
  * @returns Capabilities validation report

--- a/src/tools/xcodebuild/xcodebuild-test.ts
+++ b/src/tools/xcodebuild/xcodebuild-test.ts
@@ -1,7 +1,7 @@
 import { validateProjectPath, validateScheme } from '../../utils/validation.js';
 import { executeCommand, buildXcodebuildCommand } from '../../utils/command.js';
 import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
-import { responseCache } from '../../utils/response-cache.js';
+import { responseCache, responseResourceLink } from '../../utils/response-cache.js';
 import { projectCache, type BuildConfig } from '../../state/project-cache.js';
 import { simulatorCache } from '../../state/simulator-cache.js';
 import { createConfigManager } from '../../utils/config.js';
@@ -581,6 +581,11 @@ function formatTestResponse(
         type: 'text' as const,
         text: responseText,
       },
+      responseResourceLink(
+        cacheId,
+        'xcodebuild-test',
+        `Full test log for scheme "${config.scheme}" (${testsPassed ? 'passed' : 'failed'})`
+      ),
     ],
     isError: !testsPassed,
   };

--- a/src/tools/xcodebuild/xcodebuild-test.ts
+++ b/src/tools/xcodebuild/xcodebuild-test.ts
@@ -587,6 +587,16 @@ function formatTestResponse(
         `Full test log for scheme "${config.scheme}" (${testsPassed ? 'passed' : 'failed'})`
       ),
     ],
+    structuredContent: {
+      testId: cacheId,
+      success: testsPassed,
+      totalTests: metrics.totalTests,
+      passed: metrics.passedTests,
+      failed: metrics.failedTests,
+      skipped: metrics.skippedTests,
+      durationMs: result.duration,
+      scheme: config.scheme,
+    },
     isError: !testsPassed,
   };
 }

--- a/src/utils/response-cache.ts
+++ b/src/utils/response-cache.ts
@@ -94,6 +94,17 @@ class ResponseCache {
     }
   }
 
+  /**
+   * List all non-expired cached responses (most recent first).
+   * Used by the MCP resources layer to enumerate available `xcmcp://response/{id}` resources.
+   */
+  list(): CachedResponse[] {
+    const now = Date.now();
+    return Array.from(this.cache.values())
+      .filter(c => now - c.timestamp.getTime() <= this.maxAge)
+      .sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime());
+  }
+
   getStats(): { totalEntries: number; byTool: Record<string, number> } {
     const byTool: Record<string, number> = {};
     for (const cached of this.cache.values()) {
@@ -158,6 +169,40 @@ class ResponseCache {
 
 // Global cache instance
 export const responseCache = new ResponseCache();
+
+/** URI scheme/prefix for cached responses exposed as MCP resources. */
+export const RESPONSE_RESOURCE_PREFIX = 'xcmcp://response/';
+
+/** Build the resource URI for a cached response id. */
+export function responseResourceUri(cacheId: string): string {
+  return `${RESPONSE_RESOURCE_PREFIX}${cacheId}`;
+}
+
+/**
+ * Build an MCP `resource_link` content block for a cached response.
+ * Lets spec-aware clients fetch the full output via the resources API instead of
+ * round-tripping through a *-get-details tool call. The opaque cache id is preserved
+ * elsewhere in the response for older clients.
+ */
+export function responseResourceLink(
+  cacheId: string,
+  tool: string,
+  description: string
+): {
+  type: 'resource_link';
+  uri: string;
+  name: string;
+  description: string;
+  mimeType: string;
+} {
+  return {
+    type: 'resource_link',
+    uri: responseResourceUri(cacheId),
+    name: `${tool}-output`,
+    description,
+    mimeType: 'text/plain',
+  };
+}
 
 // Helper functions for common response patterns
 export function extractBuildSummary(output: string, stderr: string, exitCode: number) {

--- a/tests/__tests__/tools/idb-accessibility-quality-check.test.ts
+++ b/tests/__tests__/tools/idb-accessibility-quality-check.test.ts
@@ -51,6 +51,13 @@ describe('accessibility-quality-check', () => {
       expect(response.quality).toBe('rich');
       expect(response.recommendation).toBe('accessibility-ready');
       expect(response.elementCounts.tappable).toBe(4);
+
+      // Structured output (v4 outputSchema)
+      const structured = (result as any).structuredContent;
+      expect(structured).toBeDefined();
+      expect(structured.quality).toBe('rich');
+      expect(structured.recommendation).toBe('accessibility-ready');
+      expect(structured.tappableElements).toBe(4);
     });
 
     it('should classify as rich when text fields present', async () => {

--- a/tests/__tests__/tools/idb-ui-describe.test.ts
+++ b/tests/__tests__/tools/idb-ui-describe.test.ts
@@ -75,7 +75,7 @@ describe('idb-ui-describe', () => {
         y: 0,
       });
 
-      const response = JSON.parse(result.content[0].text);
+      const response = JSON.parse((result.content[0] as any).text);
       expect(response.success).toBe(true);
     });
   });
@@ -94,7 +94,7 @@ describe('idb-ui-describe', () => {
         operation: 'all',
       });
 
-      const response = JSON.parse(result.content[0].text);
+      const response = JSON.parse((result.content[0] as any).text);
 
       expect(response.success).toBe(true);
       expect(response.summary.totalElements).toBe(3);
@@ -115,7 +115,7 @@ describe('idb-ui-describe', () => {
         operation: 'all',
       });
 
-      const response = JSON.parse(result.content[0].text);
+      const response = JSON.parse((result.content[0] as any).text);
 
       expect(response.summary.dataQuality).toBe('rich');
       expect(response.summary.tappableElements).toBe(4);
@@ -134,7 +134,7 @@ describe('idb-ui-describe', () => {
         operation: 'all',
       });
 
-      const response = JSON.parse(result.content[0].text);
+      const response = JSON.parse((result.content[0] as any).text);
 
       expect(response.summary.dataQuality).toBe('rich');
       expect(response.summary.textFields).toBe(1);
@@ -153,7 +153,7 @@ describe('idb-ui-describe', () => {
         operation: 'all',
       });
 
-      const response = JSON.parse(result.content[0].text);
+      const response = JSON.parse((result.content[0] as any).text);
 
       expect(response.summary.dataQuality).toBe('minimal');
     });
@@ -171,7 +171,7 @@ describe('idb-ui-describe', () => {
         operation: 'all',
       });
 
-      const response = JSON.parse(result.content[0].text);
+      const response = JSON.parse((result.content[0] as any).text);
 
       expect(response.summary.dataQuality).toBe('minimal');
       expect(response.summary.tappableElements).toBe(0);
@@ -190,7 +190,7 @@ describe('idb-ui-describe', () => {
         operation: 'all',
       });
 
-      const response = JSON.parse(result.content[0].text);
+      const response = JSON.parse((result.content[0] as any).text);
 
       expect(response.summary.dataQuality).toBe('moderate');
       expect(response.summary.tappableElements).toBe(2);
@@ -209,7 +209,7 @@ describe('idb-ui-describe', () => {
         operation: 'all',
       });
 
-      const response = JSON.parse(result.content[0].text);
+      const response = JSON.parse((result.content[0] as any).text);
 
       expect(response.interactiveElementsPreview[0].centerX).toBe(150); // 50 + 200/2
       expect(response.interactiveElementsPreview[0].centerY).toBe(140); // 100 + 80/2
@@ -244,7 +244,7 @@ describe('idb-ui-describe', () => {
         operation: 'all',
       });
 
-      const response = JSON.parse(result.content[0].text);
+      const response = JSON.parse((result.content[0] as any).text);
 
       expect(response.success).toBe(true);
       expect(response.summary.totalElements).toBe(2);
@@ -270,7 +270,7 @@ describe('idb-ui-describe', () => {
         purposeDescription: 'Find buttons',
       });
 
-      const response = JSON.parse(result.content[0].text);
+      const response = JSON.parse((result.content[0] as any).text);
 
       expect(mockResponseCache.store).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -309,7 +309,7 @@ describe('idb-ui-describe', () => {
         operation: 'all',
       });
 
-      const response = JSON.parse(result.content[0].text);
+      const response = JSON.parse((result.content[0] as any).text);
 
       expect(response.summary.tappableElements).toBe(30);
       expect(response.interactiveElementsPreview).toHaveLength(20);
@@ -328,7 +328,7 @@ describe('idb-ui-describe', () => {
         operation: 'all',
       });
 
-      const response = JSON.parse(result.content[0].text);
+      const response = JSON.parse((result.content[0] as any).text);
 
       expect(response.summary.totalElements).toBe(2);
     });
@@ -346,7 +346,7 @@ describe('idb-ui-describe', () => {
         operation: 'all',
       });
 
-      const response = JSON.parse(result.content[0].text);
+      const response = JSON.parse((result.content[0] as any).text);
 
       // Should parse 2 valid lines and skip malformed
       expect(response.summary.totalElements).toBe(2);
@@ -365,7 +365,7 @@ describe('idb-ui-describe', () => {
         operation: 'all',
       });
 
-      const response = JSON.parse(result.content[0].text);
+      const response = JSON.parse((result.content[0] as any).text);
 
       expect(response.summary.elementTypes).toEqual({
         Button: 2,
@@ -386,7 +386,7 @@ describe('idb-ui-describe', () => {
         operation: 'all',
       });
 
-      const response = JSON.parse(result.content[0].text);
+      const response = JSON.parse((result.content[0] as any).text);
 
       expect(response.summary.tappableElements).toBe(1);
     });
@@ -402,7 +402,7 @@ describe('idb-ui-describe', () => {
         operation: 'all',
       });
 
-      const response = JSON.parse(result.content[0].text);
+      const response = JSON.parse((result.content[0] as any).text);
 
       expect(response.success).toBe(false);
       expect(response.error).toContain('IDB connection failed');
@@ -421,7 +421,7 @@ describe('idb-ui-describe', () => {
         purposeDescription: 'Find login button',
       });
 
-      const response = JSON.parse(result.content[0].text);
+      const response = JSON.parse((result.content[0] as any).text);
 
       expect(response.screenContext).toBe('LoginScreen');
       expect(response.purposeDescription).toBe('Find login button');
@@ -457,7 +457,7 @@ describe('idb-ui-describe', () => {
         y: 225,
       });
 
-      const response = JSON.parse(result.content[0].text);
+      const response = JSON.parse((result.content[0] as any).text);
 
       expect(response.success).toBe(true);
       expect(response.coordinates).toEqual({ x: 175, y: 225 });
@@ -487,7 +487,7 @@ describe('idb-ui-describe', () => {
         y: 120,
       });
 
-      const response = JSON.parse(result.content[0].text);
+      const response = JSON.parse((result.content[0] as any).text);
 
       expect(response.element.type).toBe('TextField');
       expect(response.element.label).toBe('Email');
@@ -519,7 +519,7 @@ describe('idb-ui-describe', () => {
         y: 400,
       });
 
-      const response = JSON.parse(result.content[0].text);
+      const response = JSON.parse((result.content[0] as any).text);
 
       expect(response.element.type).toBe('Button');
       expect(response.element.label).toBe('Submit');
@@ -539,7 +539,7 @@ describe('idb-ui-describe', () => {
         y: 200,
       });
 
-      const response = JSON.parse(result.content[0].text);
+      const response = JSON.parse((result.content[0] as any).text);
 
       expect(response.element.enabled).toBe(false);
       expect(response.guidance.join('\n')).toContain('Element not enabled');
@@ -558,7 +558,7 @@ describe('idb-ui-describe', () => {
         y: 100,
       });
 
-      const response = JSON.parse(result.content[0].text);
+      const response = JSON.parse((result.content[0] as any).text);
 
       expect(response.guidance.join('\n')).toContain('Type text');
       expect(response.guidance.join('\n')).toContain('idb-ui-input');
@@ -577,7 +577,7 @@ describe('idb-ui-describe', () => {
         y: 500,
       });
 
-      const response = JSON.parse(result.content[0].text);
+      const response = JSON.parse((result.content[0] as any).text);
 
       expect(response.success).toBe(false);
       expect(response.error).toContain('No element found');
@@ -652,7 +652,7 @@ describe('idb-ui-describe', () => {
         operation: 'all',
       });
 
-      const response = JSON.parse(result.content[0].text);
+      const response = JSON.parse((result.content[0] as any).text);
 
       expect(response.summary.tappableElements).toBe(1);
     });
@@ -670,7 +670,7 @@ describe('idb-ui-describe', () => {
         operation: 'all',
       });
 
-      const response = JSON.parse(result.content[0].text);
+      const response = JSON.parse((result.content[0] as any).text);
 
       expect(response.summary.tappableElements).toBe(1);
     });
@@ -688,7 +688,7 @@ describe('idb-ui-describe', () => {
         operation: 'all',
       });
 
-      const response = JSON.parse(result.content[0].text);
+      const response = JSON.parse((result.content[0] as any).text);
 
       expect(response.summary.textFields).toBe(1);
     });
@@ -706,7 +706,7 @@ describe('idb-ui-describe', () => {
         operation: 'all',
       });
 
-      const response = JSON.parse(result.content[0].text);
+      const response = JSON.parse((result.content[0] as any).text);
 
       expect(response).toHaveProperty('duration');
       expect(typeof response.duration).toBe('number');
@@ -723,7 +723,7 @@ describe('idb-ui-describe', () => {
         operation: 'all',
       });
 
-      const response = JSON.parse(result.content[0].text);
+      const response = JSON.parse((result.content[0] as any).text);
 
       expect(response.udid).toBe('test-udid-123');
       expect(response.targetName).toBe('iPhone 16 Pro');
@@ -745,7 +745,7 @@ describe('idb-ui-describe', () => {
         operation: 'all',
         filterLevel: 'strict',
       });
-      const response = JSON.parse(result.content[0].text);
+      const response = JSON.parse((result.content[0] as any).text);
 
       expect(response.summary.totalElements).toBe(3);
       expect(response.summary.tappableElements).toBe(0); // Strict misses iOS role_description
@@ -762,7 +762,7 @@ describe('idb-ui-describe', () => {
         operation: 'all',
         // filterLevel: 'moderate' (default)
       });
-      const response = JSON.parse(result.content[0].text);
+      const response = JSON.parse((result.content[0] as any).text);
 
       expect(response.summary.totalElements).toBe(3);
       expect(response.summary.tappableElements).toBe(1); // Finds button via role_description
@@ -780,7 +780,7 @@ describe('idb-ui-describe', () => {
         operation: 'all',
         filterLevel: 'permissive',
       });
-      const response = JSON.parse(result.content[0].text);
+      const response = JSON.parse((result.content[0] as any).text);
 
       expect(response.summary.totalElements).toBe(3);
       expect(response.summary.tappableElements).toBe(3); // Finds all 3 elements with AXLabel
@@ -797,7 +797,7 @@ describe('idb-ui-describe', () => {
         operation: 'all',
         filterLevel: 'none',
       });
-      const response = JSON.parse(result.content[0].text);
+      const response = JSON.parse((result.content[0] as any).text);
 
       expect(response.summary.totalElements).toBe(3);
       expect(response.summary.tappableElements).toBe(3); // Returns everything
@@ -817,7 +817,7 @@ describe('idb-ui-describe', () => {
         operation: 'all',
         filterLevel: 'moderate',
       });
-      const response = JSON.parse(result.content[0].text);
+      const response = JSON.parse((result.content[0] as any).text);
 
       expect(response.guidance.some((g: string) => g.includes('Filter level: moderate'))).toBe(
         true
@@ -835,7 +835,7 @@ describe('idb-ui-describe', () => {
         operation: 'all',
         filterLevel: 'strict',
       });
-      const response = JSON.parse(result.content[0].text);
+      const response = JSON.parse((result.content[0] as any).text);
 
       expect(
         response.guidance.some(
@@ -856,7 +856,7 @@ describe('idb-ui-describe', () => {
         operation: 'all',
         filterLevel: 'moderate',
       });
-      const response = JSON.parse(result.content[0].text);
+      const response = JSON.parse((result.content[0] as any).text);
 
       expect(
         response.guidance.some((g: string) => (g && g.includes('permissive')) || g.includes('none'))
@@ -878,7 +878,7 @@ describe('idb-ui-describe', () => {
         operation: 'all',
         filterLevel: 'moderate',
       });
-      const response = JSON.parse(result.content[0].text);
+      const response = JSON.parse((result.content[0] as any).text);
 
       expect(response.summary.tappableElements).toBe(1);
       expect(response.interactiveElementsPreview[0].role).toBe('AXButton');
@@ -897,7 +897,7 @@ describe('idb-ui-describe', () => {
         operation: 'all',
         filterLevel: 'moderate',
       });
-      const response = JSON.parse(result.content[0].text);
+      const response = JSON.parse((result.content[0] as any).text);
 
       expect(response.summary.tappableElements).toBe(1);
       expect(response.interactiveElementsPreview[0].role_description).toBe('button');
@@ -915,7 +915,7 @@ describe('idb-ui-describe', () => {
       const result = await idbUiDescribeTool({
         operation: 'all',
       });
-      const response = JSON.parse(result.content[0].text);
+      const response = JSON.parse((result.content[0] as any).text);
 
       expect(response.interactiveElementsPreview[0].label).toBe('Click Me');
     });
@@ -932,7 +932,7 @@ describe('idb-ui-describe', () => {
       const result = await idbUiDescribeTool({
         operation: 'all',
       });
-      const response = JSON.parse(result.content[0].text);
+      const response = JSON.parse((result.content[0] as any).text);
 
       expect(response.interactiveElementsPreview[0].x).toBe(25);
       expect(response.interactiveElementsPreview[0].y).toBe(50);
@@ -953,7 +953,7 @@ describe('idb-ui-describe', () => {
         operation: 'all',
         filterLevel: 'moderate',
       });
-      const response = JSON.parse(result.content[0].text);
+      const response = JSON.parse((result.content[0] as any).text);
 
       expect(response.summary.totalElements).toBe(2);
       expect(response.summary.tappableElements).toBe(2);
@@ -974,7 +974,7 @@ describe('idb-ui-describe', () => {
         operation: 'all',
         filterLevel: 'moderate',
       });
-      const response = JSON.parse(result.content[0].text);
+      const response = JSON.parse((result.content[0] as any).text);
 
       expect(response.summary.tappableElements).toBe(1);
       expect(response.interactiveElementsPreview[0].role_description).toBe('link');
@@ -993,7 +993,7 @@ describe('idb-ui-describe', () => {
         operation: 'all',
         filterLevel: 'moderate',
       });
-      const response = JSON.parse(result.content[0].text);
+      const response = JSON.parse((result.content[0] as any).text);
 
       expect(response.summary.tappableElements).toBe(1);
       expect(response.interactiveElementsPreview[0].role).toBe('AXTab');
@@ -1012,7 +1012,7 @@ describe('idb-ui-describe', () => {
         operation: 'all',
         filterLevel: 'moderate',
       });
-      const response = JSON.parse(result.content[0].text);
+      const response = JSON.parse((result.content[0] as any).text);
 
       expect(response.summary.tappableElements).toBe(0); // Disabled elements not tappable
     });
@@ -1034,7 +1034,7 @@ describe('idb-ui-describe', () => {
         filterLevel: 'strict',
         screenContext: 'Grapla Explore View',
       });
-      const response = JSON.parse(result.content[0].text);
+      const response = JSON.parse((result.content[0] as any).text);
 
       // This demonstrates the bug: strict filter misses all iOS buttons
       expect(response.summary.totalElements).toBe(5);
@@ -1054,7 +1054,7 @@ describe('idb-ui-describe', () => {
         // filterLevel: 'moderate' (default)
         screenContext: 'Grapla Explore View',
       });
-      const response = JSON.parse(result.content[0].text);
+      const response = JSON.parse((result.content[0] as any).text);
 
       // This proves the fix: moderate filter detects all iOS buttons
       expect(response.summary.totalElements).toBe(5);
@@ -1077,7 +1077,7 @@ describe('idb-ui-describe', () => {
         filterLevel: 'moderate',
         screenContext: 'Grapla Explore View',
       });
-      const response = JSON.parse(result.content[0].text);
+      const response = JSON.parse((result.content[0] as any).text);
 
       expect(response.summary.tappableElements).toBe(5);
       expect(response.summary.dataQuality).toBe('rich');
@@ -1097,7 +1097,7 @@ describe('idb-ui-describe', () => {
         operation: 'all',
         screenContext: 'Grapla Explore View',
       });
-      const response = JSON.parse(result.content[0].text);
+      const response = JSON.parse((result.content[0] as any).text);
 
       // Verify Positions button has correct coordinates
       const positionsButton = response.interactiveElementsPreview[0];
@@ -1124,7 +1124,7 @@ describe('idb-ui-describe', () => {
         operation: 'all',
         filterLevel: 'strict',
       });
-      const strictResponse = JSON.parse(strictResult.content[0].text);
+      const strictResponse = JSON.parse((strictResult.content[0] as any).text);
 
       expect(strictResponse.summary.tappableElements).toBe(0);
 
@@ -1139,7 +1139,7 @@ describe('idb-ui-describe', () => {
         operation: 'all',
         filterLevel: 'moderate',
       });
-      const moderateResponse = JSON.parse(moderateResult.content[0].text);
+      const moderateResponse = JSON.parse((moderateResult.content[0] as any).text);
 
       expect(moderateResponse.summary.tappableElements).toBe(1);
       expect(moderateResponse.summary.dataQuality).toBe('minimal'); // 1 element is still minimal (need 2-3 for moderate, >3 for rich)
@@ -1161,7 +1161,7 @@ describe('idb-ui-describe', () => {
           operation: 'all',
           filterLevel: level as any,
         });
-        const response = JSON.parse(result.content[0].text);
+        const response = JSON.parse((result.content[0] as any).text);
         results[level] = response.summary.tappableElements;
       }
 

--- a/tests/__tests__/tools/simctl-list.test.ts
+++ b/tests/__tests__/tools/simctl-list.test.ts
@@ -16,6 +16,13 @@ jest.mock('../../../src/utils/response-cache.js', () => ({
   },
   extractSimulatorSummary: jest.fn(),
   createProgressiveSimulatorResponse: jest.fn(),
+  responseResourceLink: jest.fn((cacheId: string, tool: string, description: string) => ({
+    type: 'resource_link',
+    uri: `xcmcp://response/${cacheId}`,
+    name: `${tool}-output`,
+    description,
+    mimeType: 'text/plain',
+  })),
 }));
 
 const mockSimulatorCache = simulatorCache as jest.Mocked<typeof simulatorCache>;
@@ -112,8 +119,10 @@ describe('simctlListTool', () => {
       const result = await simctlListTool({});
 
       expect(result).toHaveProperty('content');
-      expect(result.content).toHaveLength(1);
-      expect(result.content[0].type).toBe('text');
+      expect(result.content).toHaveLength(2);
+      expect((result.content[0] as any).type).toBe('text');
+      expect((result.content[1] as any).type).toBe('resource_link');
+      expect((result.content[1] as any).uri).toBe('xcmcp://response/test-cache-id');
       expect(mockSimulatorCache.getSimulatorList).toHaveBeenCalledTimes(1);
       expect(extractSimulatorSummary).toHaveBeenCalledWith(mockSimulatorList);
     });
@@ -135,18 +144,18 @@ describe('simctlListTool', () => {
     it('should return full output when concise=false', async () => {
       const result = await simctlListTool({ concise: false, outputFormat: 'json' });
 
-      expect(result.content[0].text).toContain('"devices"');
-      expect(result.content[0].text).toContain('"runtimes"');
+      expect((result.content[0] as any).text).toContain('"devices"');
+      expect((result.content[0] as any).text).toContain('"runtimes"');
     });
 
     it('should handle different output formats', async () => {
       // JSON format
       const jsonResult = await simctlListTool({ outputFormat: 'json', concise: false });
-      expect(jsonResult.content[0].text).toMatch(/^\{/); // Starts with JSON
+      expect((jsonResult.content[0] as any).text).toMatch(/^\{/); // Starts with JSON
 
       // Text format
       const textResult = await simctlListTool({ outputFormat: 'text', concise: false });
-      expect(textResult.content[0].text).toContain('Simulator List (cached at');
+      expect((textResult.content[0] as any).text).toContain('Simulator List (cached at');
     });
   });
 
@@ -212,7 +221,7 @@ describe('simctlListTool', () => {
 
     it('should return cacheId in progressive response', async () => {
       const result = await simctlListTool({ concise: true });
-      const responseData = JSON.parse(result.content[0].text);
+      const responseData = JSON.parse((result.content[0] as any).text);
 
       expect(responseData).toHaveProperty('cacheId', 'test-cache-id');
       expect(responseData).toHaveProperty('summary');
@@ -237,7 +246,7 @@ describe('simctlListTool', () => {
       });
 
       expect(result).toBeDefined();
-      expect(result.content).toHaveLength(1);
+      expect(result.content).toHaveLength(2);
     });
   });
 
@@ -279,15 +288,15 @@ describe('simctlListTool', () => {
       expect(Array.isArray(result.content)).toBe(true);
       expect(result.content[0]).toHaveProperty('type', 'text');
       expect(result.content[0]).toHaveProperty('text');
-      expect(typeof result.content[0].text).toBe('string');
+      expect(typeof (result.content[0] as any).text).toBe('string');
     });
 
     it('should ensure text is always string type', async () => {
       const result = await simctlListTool({ concise: false, outputFormat: 'json' });
-      expect(typeof result.content[0].text).toBe('string');
+      expect(typeof (result.content[0] as any).text).toBe('string');
 
       const textResult = await simctlListTool({ concise: false, outputFormat: 'text' });
-      expect(typeof textResult.content[0].text).toBe('string');
+      expect(typeof (textResult.content[0] as any).text).toBe('string');
     });
   });
 
@@ -300,7 +309,7 @@ describe('simctlListTool', () => {
     it('should use cached simulator list data', async () => {
       const result = await simctlListTool({ concise: false });
 
-      const responseData = JSON.parse(result.content[0].text);
+      const responseData = JSON.parse((result.content[0] as any).text);
       expect(responseData).toHaveProperty('devices');
       expect(responseData).toHaveProperty('runtimes');
     });
@@ -431,7 +440,7 @@ describe('simctlListTool', () => {
       mockSimulatorCache.getSimulatorList.mockResolvedValue(largeSimulatorList as any);
 
       const result = await simctlListTool({ concise: false, outputFormat: 'json' });
-      const responseData = JSON.parse(result.content[0].text);
+      const responseData = JSON.parse((result.content[0] as any).text);
 
       // Should have metadata
       expect(responseData).toHaveProperty('metadata');
@@ -489,7 +498,7 @@ describe('simctlListTool', () => {
 
       // Test max=2
       const result = await simctlListTool({ concise: false, outputFormat: 'json', max: 2 });
-      const responseData = JSON.parse(result.content[0].text);
+      const responseData = JSON.parse((result.content[0] as any).text);
 
       expect(responseData.metadata.limitApplied).toBe(2);
       expect(responseData.metadata.devicesReturned).toBe(2);
@@ -536,7 +545,7 @@ describe('simctlListTool', () => {
       mockSimulatorCache.getSimulatorList.mockResolvedValue(sortableList as any);
 
       const result = await simctlListTool({ concise: false, outputFormat: 'json', max: 3 });
-      const responseData = JSON.parse(result.content[0].text);
+      const responseData = JSON.parse((result.content[0] as any).text);
 
       const devices = Object.values(responseData.devices).flat() as any[];
       expect(devices[0].name).toBe('New Device');
@@ -576,7 +585,7 @@ describe('simctlListTool', () => {
       mockSimulatorCache.getSimulatorList.mockResolvedValue(mixedList as any);
 
       const result = await simctlListTool({ concise: false, outputFormat: 'json', max: 2 });
-      const responseData = JSON.parse(result.content[0].text);
+      const responseData = JSON.parse((result.content[0] as any).text);
 
       const devices = Object.values(responseData.devices).flat() as any[];
       // Device with lastUsed should come first
@@ -586,7 +595,7 @@ describe('simctlListTool', () => {
 
     it('should include metadata about limiting', async () => {
       const result = await simctlListTool({ concise: false, outputFormat: 'json', max: 10 });
-      const responseData = JSON.parse(result.content[0].text);
+      const responseData = JSON.parse((result.content[0] as any).text);
 
       expect(responseData.metadata).toEqual({
         totalDevicesInCache: 3,
@@ -606,7 +615,7 @@ describe('simctlListTool', () => {
     it('should return all devices when max >= total devices', async () => {
       // mockSimulatorList has 3 devices total
       const result = await simctlListTool({ concise: false, outputFormat: 'json', max: 100 });
-      const responseData = JSON.parse(result.content[0].text);
+      const responseData = JSON.parse((result.content[0] as any).text);
 
       expect(responseData.metadata.devicesReturned).toBe(3);
       expect(responseData.metadata.limitApplied).toBe(100);

--- a/tests/__tests__/tools/xcodebuild-test.test.ts
+++ b/tests/__tests__/tools/xcodebuild-test.test.ts
@@ -106,6 +106,14 @@ Test Case '-[MyAppTests testExample]' passed (0.001 seconds)`,
     expect((result.content[1] as any).uri).toBe('xcmcp://response/test-cache-id-123');
     expect(result.isError).toBe(false);
 
+    // Structured output (v4 outputSchema)
+    const structured = (result as any).structuredContent;
+    expect(structured).toBeDefined();
+    expect(structured.testId).toBe('test-cache-id-123');
+    expect(structured.success).toBe(true);
+    expect(typeof structured.totalTests).toBe('number');
+    expect(typeof structured.passed).toBe('number');
+
     const response = JSON.parse((result.content[0] as any).text);
     expect(response.testId).toBe('test-cache-id-123');
     expect(response.success).toBe(true);

--- a/tests/__tests__/tools/xcodebuild-test.test.ts
+++ b/tests/__tests__/tools/xcodebuild-test.test.ts
@@ -29,6 +29,13 @@ jest.mock('../../../src/utils/response-cache.js', () => ({
     passed: true,
     resultSummary: ['Test Suite passed'],
   })),
+  responseResourceLink: jest.fn((cacheId: string, tool: string, description: string) => ({
+    type: 'resource_link',
+    uri: `xcmcp://response/${cacheId}`,
+    name: `${tool}-output`,
+    description,
+    mimeType: 'text/plain',
+  })),
 }));
 
 jest.mock('../../../src/state/project-cache.js', () => ({
@@ -93,11 +100,13 @@ Test Case '-[MyAppTests testExample]' passed (0.001 seconds)`,
     expect(mockValidateScheme).toHaveBeenCalledWith('MyApp');
     expect(mockExecuteCommand).toHaveBeenCalled();
 
-    expect(result.content).toHaveLength(1);
-    expect(result.content[0].type).toBe('text');
+    expect(result.content).toHaveLength(2);
+    expect((result.content[0] as any).type).toBe('text');
+    expect((result.content[1] as any).type).toBe('resource_link');
+    expect((result.content[1] as any).uri).toBe('xcmcp://response/test-cache-id-123');
     expect(result.isError).toBe(false);
 
-    const response = JSON.parse(result.content[0].text);
+    const response = JSON.parse((result.content[0] as any).text);
     expect(response.testId).toBe('test-cache-id-123');
     expect(response.success).toBe(true);
     expect(response.summary.totalTests).toBeGreaterThan(0);
@@ -138,7 +147,7 @@ Test Case '-[MyAppTests testAnotherFailure]' failed (0.003 seconds)`,
 
     expect(result.isError).toBe(true);
 
-    const response = JSON.parse(result.content[0].text);
+    const response = JSON.parse((result.content[0] as any).text);
     expect(response.success).toBe(false); // Test failed
     expect(response.summary.failed).toBeGreaterThan(0);
   });
@@ -269,7 +278,7 @@ Test Case '-[MyAppTests testAnotherFailure]' failed (0.003 seconds)`,
 
     const result = await xcodebuildTestTool(args);
 
-    const response = JSON.parse(result.content[0].text);
+    const response = JSON.parse((result.content[0] as any).text);
     expect(response.cacheMetadata.hadCachedPreferences).toBe(true);
   });
 


### PR DESCRIPTION
## Phase 1 (complete) of the v4 modernization epic (#104)

Stacked on Phase 0 (#126). All five Phase-1 sub-issues.

### 1.3 — Dissolve operation-enum routers (#110)
Five routers → 22 discrete tools (`simctl-device/-app`, `idb-app`, `cache`, `persistence`). **Tool count 40 → 57.** `rtfm` repointed so discrete tools document their own (correct) usage.

### 1.1 — Tool annotations + titles (#108)
`title` + `readOnly/destructive/idempotent/openWorld` hints on all 57 tools.

### 1.2 — listChanged (#109)
`tools.listChanged` capability declared.

### 1.5 — Resources + resource_link (#112)
New `resources` capability + `xcmcp://response/{cacheId}` template backed by responseCache. `xcodebuild-build/-test`, `simctl-list`, `idb-ui-describe` emit `resource_link` blocks so clients can read full logs/trees via the resources API. Cache ids retained for back-compat.

### 1.4 — outputSchema + structuredContent (#111)
Typed, schema-validated structured output on `xcodebuild-build`, `xcodebuild-test`, `accessibility-quality-check`. Verbose JSON stays in the text block; structuredContent is a curated subset.
**Deferred (noted in #111):** structuredContent for `simctl-list` (dual-mode shape), `xcodebuild-version`/`-list` (variable parsed shapes).

### Deferred to Phase 3.2 (test sweep)
Unregistered router impl files (`device/index.ts` etc.) + stale router-name doc aliases.

### ⚠️ Breaking
Callers of `simctl-device({operation})`, `simctl-app`, `idb-app`, `cache`, `persistence` must switch to the discrete tool names. Intentional for v4.0.0; migration notes land in Phase 3.1.

### Verification (each commit)
- build clean · **1186** tests pass
- stdio: 57 tools, zero routers, all annotated+titled, `listChanged` + `resources` advertised, outputSchema in tools/list, resource read round-trips, protocol `2025-06-18`

Closes #108, #109, #110, #111, #112